### PR TITLE
Add tests for utils modules

### DIFF
--- a/__tests__/utils/googleAuth.test.js
+++ b/__tests__/utils/googleAuth.test.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+jest.mock('googleapis', () => ({ google: {} }));
+
+jest.mock('google-auth-library', () => {
+  return {
+    JWT: jest.fn().mockImplementation((options) => {
+      return {
+        authorize: jest.fn().mockResolvedValue(),
+        options,
+      };
+    }),
+  };
+});
+
+const googleAuth = require('../../utils/googleAuth');
+const { JWT } = require('google-auth-library');
+
+const utilsDir = path.resolve(__dirname, '../../utils');
+const expectedKeyPath = path.join(utilsDir, '../google-credentials.json');
+
+describe('googleAuth getClient', () => {
+  it('authorizes and returns JWT client', async () => {
+    const client = await googleAuth.getClient();
+    expect(JWT).toHaveBeenCalledWith({ keyFile: expectedKeyPath, scopes: ['https://www.googleapis.com/auth/calendar'] });
+    expect(client.authorize).toHaveBeenCalled();
+    expect(client).toBeInstanceOf(Object);
+  });
+});

--- a/__tests__/utils/importTrivia.test.js
+++ b/__tests__/utils/importTrivia.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('fs');
+jest.mock('../../db/models/TriviaQuestion', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+}));
+
+const TriviaQuestion = require('../../db/models/TriviaQuestion');
+const importTriviaFromJSON = require('../../utils/importTrivia');
+
+describe('importTriviaFromJSON', () => {
+  const triviaPath = path.join(path.resolve(__dirname, '../../utils'), '../data/nmtrivia.json');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs and exits when file missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await importTriviaFromJSON();
+    expect(fs.existsSync).toHaveBeenCalledWith(triviaPath);
+    expect(logSpy).toHaveBeenCalled();
+    expect(TriviaQuestion.create).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it('handles invalid JSON', async () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue('invalid json');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await importTriviaFromJSON();
+    expect(errorSpy).toHaveBeenCalled();
+    expect(TriviaQuestion.create).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('inserts new questions and skips existing', async () => {
+    const data = [{ question: 'q1', answer: 'a1', choices: ['a1','b1','c1','d1'] },
+                  { question: 'q2', answer: 'a2', choices: ['a2','b2','c2','d2'] }];
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify(data));
+    TriviaQuestion.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({});
+    await importTriviaFromJSON();
+    expect(TriviaQuestion.findOne).toHaveBeenCalledTimes(2);
+    expect(TriviaQuestion.create).toHaveBeenCalledTimes(1);
+    expect(TriviaQuestion.create.mock.calls[0][0]).toEqual({
+      question: 'q1',
+      correct_answer: 'a1',
+      choice_a: 'a1',
+      choice_b: 'b1',
+      choice_c: 'c1',
+      choice_d: 'd1',
+    });
+  });
+});

--- a/__tests__/utils/scheduleEmbedBuilder.test.js
+++ b/__tests__/utils/scheduleEmbedBuilder.test.js
@@ -1,11 +1,15 @@
-// --- __tests__/utils/scheduleEmbedBuilder.test.js ---
 const buildScheduleEmbed = require('../../utils/scheduleEmbedBuilder');
 
 describe('buildScheduleEmbed', () => {
-  it('builds an embed with title and description', () => {
+  it('builds an embed with custom color', () => {
     const embed = buildScheduleEmbed('Test Title', 'Test Body', 0x123456);
     expect(embed.data.title).toBe('<:newmexicoflag:1371167532697784410> Test Title');
     expect(embed.data.description).toBe('Test Body');
     expect(embed.data.color).toBe(0x123456);
+  });
+
+  it('uses default color when none provided', () => {
+    const embed = buildScheduleEmbed('Title', 'Body');
+    expect(embed.data.color).toBe(0x2ECC71);
   });
 });

--- a/__tests__/utils/scheduleFormatter.test.js
+++ b/__tests__/utils/scheduleFormatter.test.js
@@ -1,33 +1,31 @@
-// --- __tests__/utils/scheduleFormatter.test.js ---
 const formatScheduleList = require('../../utils/scheduleFormatter');
 
 describe('formatScheduleList', () => {
-    const formatTime = (date) =>
-    new Intl.DateTimeFormat('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: 'America/Chicago', // or use Intl.DateTimeFormat().resolvedOptions().timeZone
-    }).format(date);
-  
-  it('formats a list of events', () => {
-    const event1 = new Date('2025-06-01T08:00:00Z');
-    const event2 = new Date('2025-06-01T09:00:00Z');
-  
+  it('formats timed events with location', () => {
+    const e1 = new Date('2025-06-01T08:00:00Z');
+    const e2 = new Date('2025-06-01T09:00:00Z');
     const events = [
-      { summary: 'Opening Ceremony', startTime: event1, location: 'Auditorium' },
-      { summary: 'Registration', startTime: event2, location: 'Front Desk' },
+      { summary: 'Opening', startTime: e1, location: 'Hall' },
+      { summary: 'Reg', startTime: e2, location: 'Desk' },
     ];
-  
     const result = formatScheduleList(events);
-  
-    expect(result).toContain(formatTime(event1));
-    expect(result).toContain('Opening Ceremony');
-    expect(result).toContain(formatTime(event2));
-    expect(result).toContain('Registration');
-  });  
+    expect(result).toContain(e1.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }));
+    expect(result).toContain('Opening');
+    expect(result).toContain(e2.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }));
+    expect(result).toContain('Reg');
+  });
 
-  it('returns fallback for empty list', () => {
-    expect(formatScheduleList([])).toMatch("");
+  it('handles all day events and strips comma location', () => {
+    const e1 = new Date('2025-06-01T00:00:00Z');
+    const events = [
+      { summary: 'All Day', startTime: e1, location: 'Place, Somewhere' },
+    ];
+    const result = formatScheduleList(events);
+    expect(result).toContain('(All Day)');
+    expect(result).toContain('Place');
+  });
+
+  it('returns empty string for no events', () => {
+    expect(formatScheduleList([])).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- expand scheduleFormatter tests and check default color in scheduleEmbedBuilder
- add new test suites for googleAuth and importTrivia utilities

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_683ba04e36e8832db2d0e6376498fee0