### PR TITLE
Add README files to directories

### DIFF
--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -1,0 +1,11 @@
+# Test Suites
+
+This directory holds Jest test files for the BoysStateBot project.
+
+Run all tests with:
+
+```bash
+npm test
+```
+
+Subdirectories group tests by module; see `utils/` for utility tests.

--- a/__tests__/utils/README.md
+++ b/__tests__/utils/README.md
@@ -1,0 +1,9 @@
+# Utility Tests
+
+Contains Jest tests for helper functions:
+
+- `calendarPoller`
+- `scheduleEmbedBuilder`
+- `scheduleFormatter`
+
+These tests mock external services to verify expected behaviour.

--- a/commands/schedule/README.md
+++ b/commands/schedule/README.md
@@ -1,0 +1,8 @@
+# /schedule Subcommands
+
+Implements the `/schedule` command family for querying calendar events.
+
+- `today.js` – events for the current day.
+- `next.js` – upcoming event.
+- `week.js` – events for the current week.
+- `day.js` – events for an arbitrary date.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+# Data Files
+
+This folder stores static data used by the bot. Currently it contains:
+
+- `nmtrivia.json` – trivia questions and answers for the `/nmtrivia` command.
+
+Data files are loaded at runtime and can be updated without code changes.

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,9 @@
+# Database Layer
+
+Initialises Sequelize and loads model definitions.
+
+- `index.js` – sets up the Sequelize instance and associations.
+- `models/` – individual model files.
+- `sync.js` – optional script to sync tables.
+
+Configure connection details via environment variables.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+Various design notes and requirements live here.
+
+- `CalendarSystemRequirements.txt` – outlines the Google Calendar integration goals.
+
+Additional docs can be added as needed.

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -1,0 +1,7 @@
+# Interaction Handlers
+
+Code in this folder routes Discord interactions to their respective logic.
+
+- `commandHandler.js` – loads slash commands from `commands/`.
+- `interactionHandler.js` – dispatches buttons, modals and select menus.
+- `buttons/`, `modals/`, `selectMenus/` – interaction-specific handlers.

--- a/handlers/buttons/README.md
+++ b/handlers/buttons/README.md
@@ -1,0 +1,4 @@
+# Button Handlers
+
+Files in this directory respond to button interactions from Discord messages.
+Each module exports an `execute` function used by the interaction handler.

--- a/handlers/modals/README.md
+++ b/handlers/modals/README.md
@@ -1,0 +1,4 @@
+# Modal Handlers
+
+Contains handlers for Discord modal submissions. Each file exports an `execute`
+function.

--- a/handlers/selectMenus/README.md
+++ b/handlers/selectMenus/README.md
@@ -1,0 +1,4 @@
+# Select Menu Handlers
+
+Handlers for Discord select menu interactions.
+Each module should export an `execute` function called by the interaction handler.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,9 @@
+# Utility Functions
+
+Reusable helper modules supporting Google Calendar and scheduling features.
+
+- `googleAuth.js` – helper for Google API authentication.
+- `calendarPoller.js` – fetches events at intervals.
+- `scheduleFormatter.js` – formats events for display.
+- `scheduleEmbedBuilder.js` – builds rich embeds.
+- `importTrivia.js` – loads trivia questions into the database.


### PR DESCRIPTION
## Summary
- document tests location
- describe data folder contents
- add DB setup notes
- explain handlers and interaction directories
- add utility and schedule command READMEs

## Testing
- `npm test` *(fails: scheduleFormatter.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_683ba0baba90832d842264c49dc44517