### PR TITLE
Add tests for database modules

### DIFF
--- a/__tests__/db/index.test.js
+++ b/__tests__/db/index.test.js
@@ -1,0 +1,35 @@
+jest.mock('sequelize', () => ({ Sequelize: jest.fn() }));
+
+describe('db/index.js', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initialises Sequelize using environment vars', () => {
+    const mockInstance = {};
+    const { Sequelize } = require('sequelize');
+    Sequelize.mockImplementation(() => mockInstance);
+
+    process.env.DB_NAME = 'testdb';
+    process.env.DB_USER = 'user';
+    process.env.DB_PASS = 'pass';
+    process.env.DB_HOST = 'localhost';
+    process.env.DB_PORT = '3306';
+
+    jest.isolateModules(() => {
+      const sequelize = require('../../db');
+      expect(Sequelize).toHaveBeenCalledWith(
+        'testdb',
+        'user',
+        'pass',
+        expect.objectContaining({
+          host: 'localhost',
+          port: '3306',
+          dialect: 'mysql',
+          logging: false,
+        })
+      );
+      expect(sequelize).toBe(mockInstance);
+    });
+  });
+});

--- a/__tests__/db/models/CalendarConfig.test.js
+++ b/__tests__/db/models/CalendarConfig.test.js
@@ -1,0 +1,23 @@
+const mockDefine = jest.fn().mockReturnValue({ name: 'CalendarConfig' });
+jest.mock('../../../db/index', () => ({ define: mockDefine }));
+
+describe('CalendarConfig model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('defines CalendarConfig schema', () => {
+    const model = require('../../../db/models/CalendarConfig');
+    expect(mockDefine).toHaveBeenCalledWith(
+      'CalendarConfig',
+      expect.objectContaining({
+        guildId: expect.anything(),
+        calendarId: expect.anything(),
+        label: expect.anything(),
+      }),
+      expect.objectContaining({ tableName: 'calendar_configs' })
+    );
+    expect(model).toEqual({ name: 'CalendarConfig' });
+  });
+});

--- a/__tests__/db/models/CalendarEvent.test.js
+++ b/__tests__/db/models/CalendarEvent.test.js
@@ -1,0 +1,24 @@
+const mockDefine = jest.fn().mockReturnValue({ name: 'CalendarEvent' });
+jest.mock('../../../db/index', () => ({ define: mockDefine }));
+
+describe('CalendarEvent model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('defines CalendarEvent schema', () => {
+    const model = require('../../../db/models/CalendarEvent');
+    expect(mockDefine).toHaveBeenCalledWith(
+      'CalendarEvent',
+      expect.objectContaining({
+        eventId: expect.anything(),
+        summary: expect.anything(),
+        startTime: expect.anything(),
+        endTime: expect.anything(),
+      }),
+      expect.objectContaining({ tableName: 'calendar_events' })
+    );
+    expect(model).toEqual({ name: 'CalendarEvent' });
+  });
+});

--- a/__tests__/db/models/NotificationChannel.test.js
+++ b/__tests__/db/models/NotificationChannel.test.js
@@ -1,0 +1,22 @@
+const mockDefine = jest.fn().mockReturnValue({ name: 'NotificationChannel' });
+jest.mock('../../../db/index', () => ({ define: mockDefine }));
+
+describe('NotificationChannel model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('defines NotificationChannel schema', () => {
+    const model = require('../../../db/models/NotificationChannel');
+    expect(mockDefine).toHaveBeenCalledWith(
+      'NotificationChannel',
+      expect.objectContaining({
+        guildId: expect.anything(),
+        channelId: expect.anything(),
+      }),
+      expect.objectContaining({ tableName: 'notification_channels' })
+    );
+    expect(model).toEqual({ name: 'NotificationChannel' });
+  });
+});

--- a/__tests__/db/models/TriviaQuestion.test.js
+++ b/__tests__/db/models/TriviaQuestion.test.js
@@ -1,0 +1,22 @@
+const mockDefine = jest.fn().mockReturnValue({ name: 'TriviaQuestion' });
+jest.mock('../../../db/index', () => ({ define: mockDefine }));
+
+describe('TriviaQuestion model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('defines TriviaQuestion schema', () => {
+    const model = require('../../../db/models/TriviaQuestion');
+    expect(mockDefine).toHaveBeenCalledWith(
+      'TriviaQuestion',
+      expect.objectContaining({
+        question: expect.anything(),
+        correct_answer: expect.anything(),
+      }),
+      expect.objectContaining({ tableName: 'trivia_questions' })
+    );
+    expect(model).toEqual({ name: 'TriviaQuestion' });
+  });
+});

--- a/__tests__/db/models/index.test.js
+++ b/__tests__/db/models/index.test.js
@@ -1,0 +1,32 @@
+const mockSequelize = { id: 'sequelize' };
+jest.mock('../../../db/index', () => mockSequelize);
+
+jest.mock('../../../db/models/CalendarConfig', () => ({ name: 'CalendarConfig', associate: jest.fn() }));
+jest.mock('../../../db/models/CalendarEvent', () => ({ name: 'CalendarEvent', associate: jest.fn() }));
+jest.mock('../../../db/models/NotificationChannel', () => ({ name: 'NotificationChannel', associate: jest.fn() }));
+jest.mock('../../../db/models/TriviaQuestion', () => ({ name: 'TriviaQuestion', associate: jest.fn() }));
+
+describe('models/index.js', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('loads models and sets up associations', () => {
+    const db = require('../../../db/models');
+    const cfg = require('../../../db/models/CalendarConfig');
+    const event = require('../../../db/models/CalendarEvent');
+    const channel = require('../../../db/models/NotificationChannel');
+    const trivia = require('../../../db/models/TriviaQuestion');
+
+    expect(db.CalendarConfig).toBe(cfg);
+    expect(db.CalendarEvent).toBe(event);
+    expect(db.NotificationChannel).toBe(channel);
+    expect(db.TriviaQuestion).toBe(trivia);
+    expect(cfg.associate).toHaveBeenCalledWith(db);
+    expect(event.associate).toHaveBeenCalledWith(db);
+    expect(channel.associate).toHaveBeenCalledWith(db);
+    expect(trivia.associate).toHaveBeenCalledWith(db);
+    expect(db.sequelize).toBe(mockSequelize);
+  });
+});

--- a/__tests__/db/sync.test.js
+++ b/__tests__/db/sync.test.js
@@ -1,0 +1,39 @@
+jest.mock('../../db/index', () => ({
+  authenticate: jest.fn(() => Promise.resolve()),
+  sync: jest.fn(() => Promise.resolve()),
+  close: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../db/models/TriviaQuestion', () => ({}));
+
+describe('db/sync.js', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('authenticates, syncs and closes connection on import', async () => {
+    const sequelize = require('../../db/index');
+    jest.isolateModules(() => {
+      require('../../db/sync');
+    });
+    await new Promise(setImmediate);
+    expect(sequelize.authenticate).toHaveBeenCalled();
+    expect(sequelize.sync).toHaveBeenCalled();
+    expect(sequelize.close).toHaveBeenCalled();
+  });
+
+  it('logs error when authenticate fails', async () => {
+    const sequelize = require('../../db/index');
+    const error = new Error('fail');
+    sequelize.authenticate.mockRejectedValueOnce(error);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.isolateModules(() => {
+      require('../../db/sync');
+    });
+    await new Promise(setImmediate);
+    expect(errSpy).toHaveBeenCalledWith('\u274c Unable to connect to the database:', error);
+    expect(sequelize.close).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/__tests__/utils/scheduleFormatter.test.js
+++ b/__tests__/utils/scheduleFormatter.test.js
@@ -3,12 +3,10 @@ const formatScheduleList = require('../../utils/scheduleFormatter');
 
 describe('formatScheduleList', () => {
     const formatTime = (date) =>
-    new Intl.DateTimeFormat('en-US', {
+    date.toLocaleTimeString(undefined, {
       hour: '2-digit',
       minute: '2-digit',
-      hour12: false,
-      timeZone: 'America/Chicago', // or use Intl.DateTimeFormat().resolvedOptions().timeZone
-    }).format(date);
+    });
   
   it('formats a list of events', () => {
     const event1 = new Date('2025-06-01T08:00:00Z');


### PR DESCRIPTION
## Summary
- test database initialization
- test sync script
- test each Sequelize model
- ensure scheduleFormatter tests are timezone-neutral

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_683ba0790fdc832d804ad6bac262c9a5