### PR TITLE
Add handler tests

### DIFF
--- a/__tests__/handlers/buttons/confirmClearWeek.test.js
+++ b/__tests__/handlers/buttons/confirmClearWeek.test.js
@@ -1,0 +1,75 @@
+jest.mock('googleapis', () => {
+  const listMock = jest.fn();
+  const deleteMock = jest.fn();
+  return {
+    google: { calendar: jest.fn(() => ({ events: { list: listMock, delete: deleteMock } })) },
+    __esModule: true,
+    __mock: { listMock, deleteMock }
+  };
+});
+
+const { __mock } = require('googleapis');
+const listMock = __mock.listMock;
+const deleteMock = __mock.deleteMock;
+
+jest.mock('../../../utils/googleAuth', () => ({ getClient: jest.fn().mockResolvedValue({}) }));
+
+jest.mock('../../../db/models', () => {
+  const findOne = jest.fn();
+  return { CalendarConfig: { findOne }, __esModule: true, __mock: { findOne } };
+});
+
+const { __mock: dbMock } = require('../../../db/models');
+const configFindOne = dbMock.findOne;
+
+const handler = require('../../../handlers/buttons/confirmClearWeek');
+
+describe('confirmClearWeek', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects wrong user', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      customId: 'confirm_clear_week_123:456',
+      user: { id: '999' },
+      guildId: '456',
+      reply,
+    };
+    await handler(interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('handles missing config', async () => {
+    configFindOne.mockResolvedValue(null);
+    const interaction = {
+      customId: 'confirm_clear_week_123:456',
+      user: { id: '123' },
+      guildId: '456',
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+    };
+    await handler(interaction);
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: '❌ No calendar configured for this server.' });
+  });
+
+  it('deletes events and reports failures', async () => {
+    configFindOne.mockResolvedValue({ calendarId: 'cal' });
+    listMock.mockResolvedValue({ data: { items: [{ id: '1', summary: 'one' }, { id: '2', summary: 'two' }] } });
+    deleteMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('fail'));
+    const interaction = {
+      customId: 'confirm_clear_week_123:456',
+      user: { id: '123' },
+      guildId: '456',
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+    };
+    await handler(interaction);
+    const msg = interaction.editReply.mock.calls[0][0].content;
+    expect(msg).toContain('Deleted 1 events');
+    expect(msg).toContain('Failed to delete: two');
+  });
+});

--- a/__tests__/handlers/buttons/importSchedule.test.js
+++ b/__tests__/handlers/buttons/importSchedule.test.js
@@ -1,0 +1,77 @@
+jest.mock('googleapis', () => {
+  const insertMock = jest.fn();
+  return {
+    google: { calendar: jest.fn(() => ({ events: { insert: insertMock } })) },
+    __esModule: true,
+    __mock: { insertMock }
+  };
+});
+
+const { __mock } = require('googleapis');
+const insertMock = __mock.insertMock;
+
+jest.mock('../../../utils/googleAuth', () => ({ getClient: jest.fn().mockResolvedValue({}) }));
+
+jest.mock('../../../db/models', () => {
+  const findOne = jest.fn();
+  return { CalendarConfig: { findOne }, __esModule: true, __mock: { findOne } };
+});
+
+const { __mock: dbMock } = require('../../../db/models');
+const configFindOne = dbMock.findOne;
+
+jest.mock('../../../nmbs_schedule.json', () => ([
+  { summary: 'A', date: '2025-06-01', start: '10:00', end: '11:00', location: 'L' },
+  { summary: 'B', date: '2025-06-01', start: '12:00', end: '13:00', location: 'L' }
+]), { virtual: true });
+
+const handler = require('../../../handlers/buttons/importSchedule');
+
+describe('importSchedule', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects wrong user', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      customId: 'import_schedule_1:2',
+      user: { id: 'x' },
+      guildId: '2',
+      reply,
+    };
+    await handler(interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('handles missing config', async () => {
+    configFindOne.mockResolvedValue(null);
+    const interaction = {
+      customId: 'import_schedule_1:2',
+      user: { id: '1' },
+      guildId: '2',
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+    };
+    await handler(interaction);
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: '❌ No calendar configured for this server.' });
+  });
+
+  it('imports events and reports failures', async () => {
+    configFindOne.mockResolvedValue({ calendarId: 'cal' });
+    insertMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('fail'));
+    const interaction = {
+      customId: 'import_schedule_1:2',
+      user: { id: '1' },
+      guildId: '2',
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+    };
+    await handler(interaction);
+    const msg = interaction.editReply.mock.calls[0][0].content;
+    expect(msg).toContain('Imported 1 events');
+    expect(msg).toContain('Failed: B');
+  });
+});

--- a/__tests__/handlers/buttons/scheduleWeekCancel.test.js
+++ b/__tests__/handlers/buttons/scheduleWeekCancel.test.js
@@ -1,0 +1,10 @@
+const handler = require('../../../handlers/buttons/scheduleWeekCancel');
+
+describe('scheduleWeekCancel', () => {
+  it('updates interaction with cancellation message', async () => {
+    const update = jest.fn();
+    const interaction = { update };
+    await handler(interaction);
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/__tests__/handlers/buttons/scheduleWeekConfirm.test.js
+++ b/__tests__/handlers/buttons/scheduleWeekConfirm.test.js
@@ -1,0 +1,52 @@
+jest.mock('../../../utils/scheduleEmbedBuilder', () => {
+  const fn = jest.fn(() => ({ title: 'embed' }));
+  return fn;
+});
+
+jest.mock('../../../utils/scheduleFormatter', () => jest.fn(() => 'list'));
+
+const buildEmbed = require('../../../utils/scheduleEmbedBuilder');
+const formatList = require('../../../utils/scheduleFormatter');
+
+jest.mock('../../../db/models', () => {
+  const eventFindAll = jest.fn();
+  const configFindOne = jest.fn();
+  return {
+    CalendarEvent: { findAll: eventFindAll },
+    CalendarConfig: { findOne: configFindOne },
+    __esModule: true,
+    __mock: { eventFindAll, configFindOne }
+  };
+});
+
+const { __mock } = require('../../../db/models');
+const eventFindAll = __mock.eventFindAll;
+const configFindOne = __mock.configFindOne;
+
+const handler = require('../../../handlers/buttons/scheduleWeekConfirm');
+
+describe('scheduleWeekConfirm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles missing config dates', async () => {
+    configFindOne.mockResolvedValue(null);
+    const interaction = { update: jest.fn(), guildId: '1' };
+    await handler(interaction);
+    expect(interaction.update).toHaveBeenCalled();
+    expect(buildEmbed).toHaveBeenCalled();
+  });
+
+  it('shows events from database', async () => {
+    configFindOne.mockResolvedValue({ startDate: '2025-06-01', endDate: '2025-06-02', guildId: '1' });
+    eventFindAll.mockResolvedValue([
+      { startTime: new Date('2025-06-01T10:00:00Z'), summary: 'A' },
+      { startTime: new Date('2025-06-02T10:00:00Z'), summary: 'B' }
+    ]);
+    const interaction = { update: jest.fn(), followUp: jest.fn(), guildId: '1' };
+    await handler(interaction);
+    expect(interaction.update).toHaveBeenCalled();
+    expect(buildEmbed).toHaveBeenCalled();
+  });
+});

--- a/__tests__/handlers/commandHandler.test.js
+++ b/__tests__/handlers/commandHandler.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+jest.mock('fs');
+
+jest.mock('discord.js', () => {
+  const restPutMock = jest.fn();
+  const routeMock = jest.fn(() => 'route');
+  return {
+    REST: jest.fn().mockImplementation(() => ({
+      put: restPutMock,
+      setToken() { return this; }
+    })),
+    Routes: { applicationGuildCommands: routeMock },
+    __esModule: true,
+    __mock: { restPutMock, routeMock }
+  };
+});
+
+const { __mock } = require('discord.js');
+const restPutMock = __mock.restPutMock;
+const routeMock = __mock.routeMock;
+
+jest.mock('../../commands/good.js', () => ({
+  data: { name: 'good', toJSON: jest.fn(() => ({ name: 'good' })) },
+  execute: jest.fn()
+}), { virtual: true });
+
+jest.mock('../../commands/bad.js', () => ({
+  data: { name: 'bad' }
+}), { virtual: true });
+
+const handler = require('../../handlers/commandHandler');
+
+describe('commandHandler', () => {
+  let client;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = { commands: new Map(), user: { id: 'uid' } };
+    process.env.DISCORD_TOKEN = 'token';
+    process.env.GUILD_ID = 'gid';
+    fs.readdirSync.mockReturnValue(['good.js', 'bad.js']);
+  });
+
+  it('loads valid commands and registers them', async () => {
+    await handler(client);
+    expect(client.commands.has('good')).toBe(true);
+    expect(restPutMock).toHaveBeenCalledWith('route', { body: [{ name: 'good' }] });
+  });
+
+  it('skips invalid command modules', async () => {
+    await handler(client);
+    expect(client.commands.has('bad')).toBe(false);
+  });
+});

--- a/__tests__/handlers/interactionHandler.test.js
+++ b/__tests__/handlers/interactionHandler.test.js
@@ -1,0 +1,86 @@
+const mockedSelect = jest.fn();
+const mockedModal = jest.fn();
+const mockedButton = jest.fn();
+
+jest.mock('../../handlers/selectMenus/editCalendarSelect.js', () => mockedSelect, { virtual: true });
+jest.mock('../../handlers/modals/editCalendarModal.js', () => mockedModal, { virtual: true });
+jest.mock('../../handlers/buttons/scheduleWeekCancel.js', () => mockedButton, { virtual: true });
+
+const handler = require('../../handlers/interactionHandler');
+
+describe('interactionHandler', () => {
+  let client;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = { commands: new Map() };
+  });
+
+  it('executes a chat input command', async () => {
+    const cmd = { execute: jest.fn() };
+    client.commands.set('ping', cmd);
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'ping',
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      isButton: () => false,
+    };
+    await handler(client, interaction);
+    expect(cmd.execute).toHaveBeenCalledWith(interaction);
+  });
+
+  it('replies when command execution fails', async () => {
+    const cmd = { execute: jest.fn().mockRejectedValue(new Error('fail')) };
+    client.commands.set('ping', cmd);
+    const reply = jest.fn();
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'ping',
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      isButton: () => false,
+      replied: false,
+      deferred: false,
+      reply,
+    };
+    await handler(client, interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('calls select menu handler', async () => {
+    const interaction = {
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => true,
+      customId: 'edit_calendar_select_123',
+      isModalSubmit: () => false,
+      isButton: () => false,
+    };
+    await handler(client, interaction);
+    expect(mockedSelect).toHaveBeenCalledWith(interaction);
+  });
+
+  it('calls modal handler', async () => {
+    const interaction = {
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => true,
+      customId: 'edit_calendar_modal_1',
+      isButton: () => false,
+    };
+    await handler(client, interaction);
+    expect(mockedModal).toHaveBeenCalledWith(interaction);
+  });
+
+  it('calls button handler', async () => {
+    const interaction = {
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      isButton: () => true,
+      customId: 'schedule_week_cancel_1',
+    };
+    await handler(client, interaction);
+    expect(mockedButton).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/handlers/modals/editCalendarModal.test.js
+++ b/__tests__/handlers/modals/editCalendarModal.test.js
@@ -1,0 +1,41 @@
+jest.mock('../../../db/models/CalendarConfig', () => {
+  const findByPk = jest.fn();
+  return { findByPk, __esModule: true, __mock: { findByPk } };
+});
+
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findByPk = __mock.findByPk;
+
+const handler = require('../../../handlers/modals/editCalendarModal');
+
+describe('editCalendarModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('replies when calendar not found', async () => {
+    findByPk.mockResolvedValue(null);
+    const reply = jest.fn();
+    const interaction = {
+      customId: 'edit_calendar_modal_1',
+      fields: { getTextInputValue: jest.fn(() => 'new') },
+      reply,
+    };
+    await handler(interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  it('updates label and replies', async () => {
+    const update = jest.fn();
+    findByPk.mockResolvedValue({ id: 1, calendarId: 'cal', update });
+    const reply = jest.fn();
+    const interaction = {
+      customId: 'edit_calendar_modal_1',
+      fields: { getTextInputValue: jest.fn(() => 'new') },
+      reply,
+    };
+    await handler(interaction);
+    expect(update).toHaveBeenCalledWith({ label: 'new' });
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/handlers/selectMenus/editCalendarSelect.test.js
+++ b/__tests__/handlers/selectMenus/editCalendarSelect.test.js
@@ -1,0 +1,37 @@
+jest.mock('discord.js', () => {
+  class FakeModal { setCustomId(id){ this.id=id; return this; } setTitle(){return this;} addComponents(){return this;} }
+  class FakeText { setCustomId(){return this;} setLabel(){return this;} setStyle(){return this;} setRequired(){return this;} }
+  class FakeRow { addComponents(){return this;} }
+  const TextInputStyle = { Short: 1 };
+  return { ModalBuilder: FakeModal, TextInputBuilder: FakeText, TextInputStyle, ActionRowBuilder: FakeRow };
+});
+
+jest.mock('../../../db/models/CalendarConfig', () => {
+  const findByPk = jest.fn();
+  return { findByPk, __esModule: true, __mock: { findByPk } };
+});
+
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findByPk = __mock.findByPk;
+
+const handler = require('../../../handlers/selectMenus/editCalendarSelect');
+
+describe('editCalendarSelect', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('handles missing calendar', async () => {
+    findByPk.mockResolvedValue(null);
+    const update = jest.fn();
+    const interaction = { values: ['1'], update };
+    await handler(interaction);
+    expect(update).toHaveBeenCalledWith({ content: '❌ Calendar not found.', components: [] });
+  });
+
+  it('shows modal for existing calendar', async () => {
+    findByPk.mockResolvedValue({ id: 2 });
+    const showModal = jest.fn();
+    const interaction = { values: ['2'], showModal };
+    await handler(interaction);
+    expect(showModal).toHaveBeenCalledWith(expect.objectContaining({ id: 'edit_calendar_modal_2' }));
+  });
+});

--- a/__tests__/handlers/selectMenus/removeCalendarSelect.test.js
+++ b/__tests__/handlers/selectMenus/removeCalendarSelect.test.js
@@ -1,0 +1,31 @@
+jest.mock('../../../db/models/CalendarConfig', () => {
+  const findByPk = jest.fn();
+  return { findByPk, __esModule: true, __mock: { findByPk } };
+});
+
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findByPk = __mock.findByPk;
+
+const handler = require('../../../handlers/selectMenus/removeCalendarSelect');
+
+describe('removeCalendarSelect', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('handles missing calendar', async () => {
+    findByPk.mockResolvedValue(null);
+    const update = jest.fn();
+    const interaction = { values: ['1'], update };
+    await handler(interaction);
+    expect(update).toHaveBeenCalledWith({ content: '❌ Calendar not found.', components: [] });
+  });
+
+  it('destroys calendar and updates', async () => {
+    const destroy = jest.fn();
+    findByPk.mockResolvedValue({ id: 2, calendarId: 'cal', destroy });
+    const update = jest.fn();
+    const interaction = { values: ['2'], update };
+    await handler(interaction);
+    expect(destroy).toHaveBeenCalled();
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/__tests__/handlers/selectMenus/setDaterangeSelect.test.js
+++ b/__tests__/handlers/selectMenus/setDaterangeSelect.test.js
@@ -1,0 +1,31 @@
+jest.mock('../../../db/models', () => {
+  const update = jest.fn();
+  return { CalendarConfig: { update }, __esModule: true, __mock: { update } };
+});
+
+const { __mock } = require('../../../db/models');
+const updateModel = __mock.update;
+
+const handler = require('../../../handlers/selectMenus/setDaterangeSelect');
+
+describe('setDaterangeSelect', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('updates date range and interaction', async () => {
+    const interaction = {
+      customId: 'set-daterange:2025-06-01:2025-06-02',
+      values: ['cal'],
+      guildId: '1',
+      update: jest.fn()
+    };
+    await handler(interaction);
+    expect(updateModel).toHaveBeenCalledWith(
+      { startDate: '2025-06-01', endDate: '2025-06-02' },
+      { where: { guildId: '1', calendarId: 'cal' } }
+    );
+    expect(interaction.update).toHaveBeenCalledWith({
+      content: '✅ Date range set for **cal**: 2025-06-01 → 2025-06-02',
+      components: []
+    });
+  });
+});

--- a/__tests__/utils/scheduleFormatter.test.js
+++ b/__tests__/utils/scheduleFormatter.test.js
@@ -3,12 +3,10 @@ const formatScheduleList = require('../../utils/scheduleFormatter');
 
 describe('formatScheduleList', () => {
     const formatTime = (date) =>
-    new Intl.DateTimeFormat('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: 'America/Chicago', // or use Intl.DateTimeFormat().resolvedOptions().timeZone
-    }).format(date);
+      date.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
   
   it('formats a list of events', () => {
     const event1 = new Date('2025-06-01T08:00:00Z');


### PR DESCRIPTION
## Summary
- add tests for every handler module and subfolder
- fix timezone expectation in scheduleFormatter test

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_683ba0377854832da40f72614d72132b