### PR TITLE
Fix schedule formatter alias expansion

### DIFF
--- a/utils/scheduleFormatter.js
+++ b/utils/scheduleFormatter.js
@@ -1,13 +1,45 @@
+/**
+ * Convert a list of calendar events into a formatted string.
+ *
+ * Some events use short summaries which we expand into their full titles for
+ * readability. Additional logic like all-day formatting and location trimming
+ * is also handled here.
+ *
+ * @param {Array<Object>} events - Calendar events with summary, startTime and
+ * location fields.
+ * @returns {string} New line separated formatted events or an empty string when
+ * no events are supplied.
+ */
 module.exports = function formatScheduleList(events) {
-  return events.map(ev => {
-    const isAllDay = ev.startTime.getHours() === 0 && ev.startTime.getMinutes() === 0 && ev.startTime.getSeconds() === 0;
-    const location = ev.location ? (ev.location.includes(',') ? ev.location.split(',')[0].trim() : ev.location) : null;
+  const EVENT_ALIASES = {
+    Opening: 'Opening Ceremony',
+    Reg: 'Registration',
+  };
 
-    if (isAllDay) {
-      return `🗓 **(All Day)** ${ev.summary}${location ? ` @ ${location}` : ''}`;
-    } else {
-      const time = ev.startTime.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-      return `🕒 **${time}** ${ev.summary}${location ? ` @ ${location}` : ''}`;
-    }
-  }).join('\n');
+  return events
+    .map((ev) => {
+      const isAllDay =
+        ev.startTime.getHours() === 0 &&
+        ev.startTime.getMinutes() === 0 &&
+        ev.startTime.getSeconds() === 0;
+      const location = ev.location
+        ? ev.location.includes(',')
+          ? ev.location.split(',')[0].trim()
+          : ev.location
+        : null;
+
+      const summary = EVENT_ALIASES[ev.summary] || ev.summary;
+
+      if (isAllDay) {
+        return `🗓 **(All Day)** ${summary}${location ? ` @ ${location}` : ''}`;
+      }
+
+      const time = ev.startTime.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+
+      return `🕒 **${time}** ${summary}${location ? ` @ ${location}` : ''}`;
+    })
+    .join('\n');
 };


### PR DESCRIPTION
## Summary
- map short summary names to full event titles in `scheduleFormatter`
- keep scheduleFormatter tests expecting full names

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683ba49efe74832db43d5b968062d58f