### PR TITLE
Fix nmtrivia timer teardown

### DIFF
--- a/commands/nmtrivia.js
+++ b/commands/nmtrivia.js
@@ -78,6 +78,10 @@ module.exports = {
       }
     }, 5000);
 
+    if (typeof countdownInterval.unref === 'function') {
+      countdownInterval.unref();
+    }
+
     const filter = m => {
       if (m.author.bot) return false;
       const firstChar = m.content.trim().charAt(0).toLowerCase();


### PR DESCRIPTION
## Summary
- prevent stray timers in `nmtrivia` command by calling `unref` when available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bba3f8e48832d9b860bc52f2d669d