### PR TITLE
Fix scheduleFormatter timezone

### DIFF
--- a/__tests__/utils/scheduleFormatter.test.js
+++ b/__tests__/utils/scheduleFormatter.test.js
@@ -35,4 +35,20 @@ describe('formatScheduleList', () => {
     expect(result).toContain('Dinner');
     expect(result).not.toContain('@');
   });
+
+  it('detects all-day events using UTC time', () => {
+    const fakeDate = {
+      getUTCHours: () => 0,
+      getUTCMinutes: () => 0,
+      getUTCSeconds: () => 0,
+      getHours: () => 17,
+      getMinutes: () => 0,
+      getSeconds: () => 0,
+      toLocaleTimeString: () => '05:00 PM',
+    };
+
+    const events = [{ summary: 'Meeting', startTime: fakeDate }];
+    const result = formatScheduleList(events);
+    expect(result).toContain('(All Day)');
+  });
 });

--- a/utils/scheduleFormatter.js
+++ b/utils/scheduleFormatter.js
@@ -19,9 +19,9 @@ module.exports = function formatScheduleList(events) {
   return events
     .map((ev) => {
       const isAllDay =
-        ev.startTime.getHours() === 0 &&
-        ev.startTime.getMinutes() === 0 &&
-        ev.startTime.getSeconds() === 0;
+        ev.startTime.getUTCHours() === 0 &&
+        ev.startTime.getUTCMinutes() === 0 &&
+        ev.startTime.getUTCSeconds() === 0;
       const location = ev.location
         ? ev.location.includes(',')
           ? ev.location.split(',')[0].trim()


### PR DESCRIPTION
## Summary
- handle all-day events using UTC time
- add regression test for UTC detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c3c604224832dac60c6483a0242b5