### PR TITLE
Add missing READMEs and documentation tests

### DIFF
--- a/__mocks__/README.md
+++ b/__mocks__/README.md
@@ -1,0 +1,3 @@
+# Jest Mocks
+
+Custom manual mocks used in the test suite. Currently provides a stub of `discord.js` for unit tests.

--- a/__tests__/commands/README.md
+++ b/__tests__/commands/README.md
@@ -1,0 +1,3 @@
+# Command Tests
+
+Contains tests for each slash command. Interaction replies are mocked to verify correct behaviour.

--- a/__tests__/db/README.md
+++ b/__tests__/db/README.md
@@ -1,0 +1,3 @@
+# Database Tests
+
+Jest tests for Sequelize models and database sync logic.

--- a/__tests__/db/models/README.md
+++ b/__tests__/db/models/README.md
@@ -1,0 +1,3 @@
+# Model Tests
+
+Unit tests for individual Sequelize models such as `CalendarEvent` and `TriviaQuestion`.

--- a/__tests__/handlers/README.md
+++ b/__tests__/handlers/README.md
@@ -1,0 +1,8 @@
+# Handler Tests
+
+Jest tests for the interaction handlers. Files here verify that buttons, modals, and select menu handlers behave correctly.
+
+Subfolders group tests by interaction type:
+- `buttons/`
+- `modals/`
+- `selectMenus/`

--- a/__tests__/handlers/buttons/README.md
+++ b/__tests__/handlers/buttons/README.md
@@ -1,0 +1,3 @@
+# Button Handler Tests
+
+Unit tests for button interaction handlers. Each test mocks Discord.js button interactions to confirm expected behaviour such as schedule confirmations.

--- a/__tests__/handlers/modals/README.md
+++ b/__tests__/handlers/modals/README.md
@@ -1,0 +1,3 @@
+# Modal Handler Tests
+
+Tests for modal submissions. These ensure that user input is validated and processed correctly.

--- a/__tests__/handlers/selectMenus/README.md
+++ b/__tests__/handlers/selectMenus/README.md
@@ -1,0 +1,3 @@
+# Select Menu Handler Tests
+
+Tests covering select menu interactions used for calendar editing and date range selection.

--- a/__tests__/readmeFiles.test.js
+++ b/__tests__/readmeFiles.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Repository documentation', () => {
+  const directories = [
+    '__mocks__',
+    '__tests__/handlers',
+    '__tests__/handlers/selectMenus',
+    '__tests__/handlers/modals',
+    '__tests__/handlers/buttons',
+    '__tests__/db',
+    '__tests__/db/models',
+    '__tests__/commands',
+  ];
+
+  directories.forEach((dir) => {
+    test(`${dir} has README.md with a heading`, () => {
+      const filePath = path.join(__dirname, '..', dir, 'README.md');
+      expect(fs.existsSync(filePath)).toBe(true);
+      const firstLine = fs.readFileSync(filePath, 'utf8').split('\n')[0];
+      expect(firstLine.startsWith('# ')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add README files for directories missing documentation
- ensure README files exist with a meta Jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c3fb042b4832db7dbda21088d4034