### PR TITLE
Add tests for calendar and schedule subcommands

### DIFF
--- a/__tests__/commands/calendar/edit.test.js
+++ b/__tests__/commands/calendar/edit.test.js
@@ -1,0 +1,31 @@
+jest.mock('../../../db/models/CalendarConfig', () => {
+  const findAll = jest.fn();
+  return { findAll, __esModule: true, __mock: { findAll } };
+});
+
+jest.mock('discord.js', () => {
+  class Fake { setCustomId(){return this;} setTitle(){return this;} addComponents(){return this;} setLabel(){return this;} setStyle(){return this;} setRequired(){return this;} setPlaceholder(){return this;} addOptions(){return this;} }
+  return { ModalBuilder: Fake, TextInputBuilder: Fake, TextInputStyle: { Short: 1 }, ActionRowBuilder: Fake, StringSelectMenuBuilder: Fake, StringSelectMenuOptionBuilder: Fake };
+});
+
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findAll = __mock.findAll;
+const edit = require('../../../commands/calendar/edit');
+
+describe('calendar edit', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies when no calendars', async () => {
+    findAll.mockResolvedValue([]);
+    const reply = jest.fn();
+    await edit({ reply }, 'g1');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('shows modal when one calendar', async () => {
+    findAll.mockResolvedValue([{ id: 2 }]);
+    const showModal = jest.fn();
+    await edit({ showModal }, 'g1');
+    expect(showModal).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/link.test.js
+++ b/__tests__/commands/calendar/link.test.js
@@ -1,0 +1,37 @@
+jest.mock('../../../db/models', () => {
+  const findOne = jest.fn();
+  return { CalendarConfig: { findOne }, __esModule: true, __mock: { findOne } };
+});
+
+jest.mock('discord.js', () => ({
+  EmbedBuilder: class {
+    constructor(){this.data={};}
+    setTitle(t){this.data.title=t;return this;}
+    setDescription(d){this.data.description=d;return this;}
+    setColor(c){this.data.color=c;return this;}
+    setFooter(){return this;}
+    setTimestamp(){return this;}
+  }
+}));
+
+const { CalendarConfig, __mock } = require('../../../db/models');
+const findOne = CalendarConfig.findOne;
+const link = require('../../../commands/calendar/link');
+
+describe('calendar link', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies when config missing', async () => {
+    findOne.mockResolvedValue(null);
+    const reply = jest.fn();
+    await link({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('sends embed when config exists', async () => {
+    findOne.mockResolvedValue({ calendarId: 'id', startDate: '2023-08-20' });
+    const reply = jest.fn();
+    await link({ reply }, 'g');
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: [expect.any(Object)] }));
+  });
+});

--- a/__tests__/commands/calendar/list.test.js
+++ b/__tests__/commands/calendar/list.test.js
@@ -1,0 +1,22 @@
+jest.mock('../../../db/models/CalendarConfig', () => { const findAll = jest.fn(); return { findAll, __esModule: true, __mock: { findAll } }; });
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findAll = __mock.findAll;
+const list = require('../../../commands/calendar/list');
+
+describe('calendar list', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies when none', async () => {
+    findAll.mockResolvedValue([]);
+    const reply = jest.fn();
+    await list({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('lists calendars', async () => {
+    findAll.mockResolvedValue([{ calendarId: 'id', label: 'label' }]);
+    const reply = jest.fn();
+    await list({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/list_channels.test.js
+++ b/__tests__/commands/calendar/list_channels.test.js
@@ -1,0 +1,27 @@
+jest.mock('../../../db/models', () => {
+  const findAll = jest.fn();
+  return { NotificationChannels: { findAll }, __esModule: true, __mock: { findAll } };
+});
+
+const { NotificationChannels, __mock } = require('../../../db/models');
+const findAll = NotificationChannels.findAll;
+const list = require('../../../commands/calendar/list-channels');
+
+describe('calendar list-channels', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no channels configured', async () => {
+    findAll.mockResolvedValue([]);
+    const reply = jest.fn();
+    await list({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('lists channels', async () => {
+    findAll.mockResolvedValue([{ channelId: '1' }]);
+    const reply = jest.fn();
+    const guild = { channels: { cache: new Map([['1', { name: 'general' }]]) } };
+    await list({ guild, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/remove.test.js
+++ b/__tests__/commands/calendar/remove.test.js
@@ -1,0 +1,24 @@
+jest.mock('../../../db/models/CalendarConfig', () => { const findAll = jest.fn(); return { findAll, __esModule: true, __mock: { findAll } }; });
+const { __mock } = require('../../../db/models/CalendarConfig');
+const findAll = __mock.findAll;
+const remove = require('../../../commands/calendar/remove');
+
+describe('calendar remove', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no calendars', async () => {
+    findAll.mockResolvedValue([]);
+    const reply = jest.fn();
+    await remove({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('one calendar', async () => {
+    const destroy = jest.fn();
+    findAll.mockResolvedValue([{ id:1, calendarId:'c', destroy }]);
+    const reply = jest.fn();
+    await remove({ reply }, 'g');
+    expect(destroy).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/remove_channel.test.js
+++ b/__tests__/commands/calendar/remove_channel.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../db/models', () => { const destroy = jest.fn(); return { NotificationChannels: { destroy }, __esModule: true, __mock: { destroy } }; });
+
+const { NotificationChannels, __mock } = require('../../../db/models');
+const destroy = NotificationChannels.destroy;
+const handler = require('../../../commands/calendar/remove-channel');
+
+describe('calendar remove-channel', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('not found', async () => {
+    destroy.mockResolvedValue(0);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => '1') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('removed', async () => {
+    destroy.mockResolvedValue(1);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => '1') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/set.test.js
+++ b/__tests__/commands/calendar/set.test.js
@@ -1,0 +1,36 @@
+jest.mock('googleapis', () => {
+  const getMock = jest.fn();
+  return { google: { auth: { GoogleAuth: jest.fn().mockReturnValue({}) }, calendar: jest.fn(() => ({ calendars: { get: getMock } })) }, __esModule: true, __mock: { getMock } };
+});
+
+jest.mock('../../../db/models/CalendarConfig', () => {
+  const destroy = jest.fn();
+  const create = jest.fn();
+  return { destroy, create, __esModule: true, __mock: { destroy, create } };
+});
+
+const { __mock: gMock } = require('googleapis');
+const { __mock: dbMock } = require('../../../db/models/CalendarConfig');
+const setCmd = require('../../../commands/calendar/set');
+
+describe('calendar set', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('handles calendar not found', async () => {
+    gMock.getMock.mockRejectedValue({ code: 404 });
+    const reply = jest.fn();
+    const options = { getString: jest.fn(), getBoolean: jest.fn() };
+    await setCmd({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('creates calendar when valid', async () => {
+    gMock.getMock.mockResolvedValue({ data: { summary: 'Cal' } });
+    const reply = jest.fn();
+    const options = { getString: jest.fn(key => key==='calendar_id'? 'id':'label'), getBoolean: jest.fn(() => true) };
+    await setCmd({ options, reply }, 'g');
+    expect(dbMock.destroy).toHaveBeenCalled();
+    expect(dbMock.create).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/set_channel.test.js
+++ b/__tests__/commands/calendar/set_channel.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../db/models/NotificationChannel', () => { const upsert = jest.fn(); return { upsert, __esModule: true, __mock: { upsert } }; });
+const { __mock } = require('../../../db/models/NotificationChannel');
+const upsert = __mock.upsert;
+const setChannel = require('../../../commands/calendar/set-channel');
+
+describe('calendar set-channel', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('requires admin', async () => {
+    const reply = jest.fn();
+    const member = { permissions: { has: () => false } };
+    await setChannel({ member, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('sets channel', async () => {
+    upsert.mockResolvedValue();
+    const reply = jest.fn();
+    const member = { permissions: { has: () => true } };
+    const options = { getChannel: jest.fn(() => ({ id: '1' })) };
+    await setChannel({ member, options, reply }, 'g');
+    expect(upsert).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/calendar/set_daterange.test.js
+++ b/__tests__/commands/calendar/set_daterange.test.js
@@ -1,0 +1,28 @@
+jest.mock('../../../db/models', () => { const findAll = jest.fn(); return { CalendarConfig: { findAll }, __esModule: true, __mock: { findAll } }; });
+
+jest.mock('discord.js', () => ({ StringSelectMenuBuilder: class { setCustomId(){return this;} setPlaceholder(){return this;} addOptions(){return this;} }, ActionRowBuilder: class { addComponents(){return this;} } }));
+
+const { CalendarConfig, __mock } = require('../../../db/models');
+const findAll = CalendarConfig.findAll;
+const handler = require('../../../commands/calendar/set-daterange');
+
+describe('calendar set-daterange', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('invalid date format', async () => {
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'bad') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('single calendar updates', async () => {
+    const update = jest.fn();
+    findAll.mockResolvedValue([{ label: 'a', calendarId: 'id', update }]);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(key => key === 'start' ? '2023-01-01' : '2023-01-02') };
+    await handler({ options, reply }, 'g');
+    expect(update).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/schedule/day.test.js
+++ b/__tests__/commands/schedule/day.test.js
@@ -1,0 +1,38 @@
+jest.mock('../../../db/models', () => {
+  const findOne = jest.fn();
+  const findAll = jest.fn();
+  return { CalendarConfig: { findOne }, CalendarEvent: { findAll }, __esModule: true, __mock: { findOne, findAll } };
+});
+
+jest.mock('../../../utils/scheduleFormatter', () => jest.fn(() => 'list'));
+jest.mock('../../../utils/scheduleEmbedBuilder', () => jest.fn(() => ({ data: {} })));
+
+const { __mock } = require('../../../db/models');
+const configFind = __mock.findOne;
+const eventFind = __mock.findAll;
+const dayCmd = require('../../../commands/schedule/day');
+
+const scheduleEmbedBuilder = require('../../../utils/scheduleEmbedBuilder');
+
+describe('schedule day', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no config', async () => {
+    configFind.mockResolvedValue(null);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'monday') };
+    await dayCmd({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('shows events', async () => {
+    configFind.mockResolvedValue({ startDate: '2023-01-01', endDate: '2023-12-31' });
+    eventFind.mockResolvedValue([{ id:1 }]);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'monday') };
+    await dayCmd({ options, reply }, 'g');
+    expect(eventFind).toHaveBeenCalled();
+    expect(scheduleEmbedBuilder).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/schedule/next.test.js
+++ b/__tests__/commands/schedule/next.test.js
@@ -1,0 +1,30 @@
+jest.mock('../../../db/models', () => { const findOne = jest.fn(); const findOneEvent = jest.fn(); return { CalendarConfig: { findOne }, CalendarEvent: { findOne: findOneEvent }, __esModule: true, __mock: { findOne, findOneEvent } }; });
+jest.mock('../../../utils/scheduleFormatter', () => jest.fn(() => 'list'));
+jest.mock('../../../utils/scheduleEmbedBuilder', () => jest.fn(() => ({ data: {} })));
+
+const { __mock } = require('../../../db/models');
+const configFind = __mock.findOne;
+const eventFind = __mock.findOneEvent;
+const nextCmd = require('../../../commands/schedule/next');
+const scheduleEmbedBuilder = require('../../../utils/scheduleEmbedBuilder');
+
+describe('schedule next', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no upcoming event', async () => {
+    configFind.mockResolvedValue({ startDate: '2023-01-01', endDate: '2023-12-31' });
+    eventFind.mockResolvedValue(null);
+    const reply = jest.fn();
+    await nextCmd({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('shows next event', async () => {
+    configFind.mockResolvedValue({ startDate: '2023-01-01', endDate: '2023-12-31' });
+    eventFind.mockResolvedValue({});
+    const reply = jest.fn();
+    await nextCmd({ reply }, 'g');
+    expect(scheduleEmbedBuilder).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/schedule/today.test.js
+++ b/__tests__/commands/schedule/today.test.js
@@ -1,0 +1,20 @@
+jest.mock('../../../db/models', () => { const findOne = jest.fn(); const findAll = jest.fn(); return { CalendarConfig: { findOne }, CalendarEvent: { findAll }, __esModule: true, __mock: { findOne, findAll } }; });
+jest.mock('../../../utils/scheduleFormatter', () => jest.fn(() => 'list'));
+jest.mock('../../../utils/scheduleEmbedBuilder', () => jest.fn(() => ({ data: {} })));
+
+const { __mock } = require('../../../db/models');
+const configFind = __mock.findOne;
+const eventFind = __mock.findAll;
+const todayCmd = require('../../../commands/schedule/today');
+
+describe('schedule today', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no events today', async () => {
+    configFind.mockResolvedValue({ startDate: '2023-01-01', endDate: '2023-12-31' });
+    eventFind.mockResolvedValue([]);
+    const reply = jest.fn();
+    await todayCmd({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/schedule/week.test.js
+++ b/__tests__/commands/schedule/week.test.js
@@ -1,0 +1,9 @@
+const week = require('../../../commands/schedule/week');
+
+describe('schedule week', () => {
+  test('asks for confirmation', async () => {
+    const reply = jest.fn();
+    await week({ reply });
+    expect(reply).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add new Jest tests covering calendar subcommand modules
- add tests for schedule subcommand modules

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683c3f48873c832da100a86d1d6e666b