### PR TITLE
Improve README presence test

### DIFF
--- a/__tests__/readmeFiles.test.js
+++ b/__tests__/readmeFiles.test.js
@@ -2,20 +2,25 @@ const fs = require('fs');
 const path = require('path');
 
 describe('Repository documentation', () => {
-  const directories = [
-    '__mocks__',
-    '__tests__/handlers',
-    '__tests__/handlers/selectMenus',
-    '__tests__/handlers/modals',
-    '__tests__/handlers/buttons',
-    '__tests__/db',
-    '__tests__/db/models',
-    '__tests__/commands',
-  ];
+  const repoRoot = path.join(__dirname, '..');
+  const excluded = new Set(['node_modules', '.git', 'coverage']);
+
+  const getDirectories = (dir) => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && !excluded.has(entry.name))
+      .flatMap((entry) => {
+        const res = path.join(dir, entry.name);
+        return [res, ...getDirectories(res)];
+      });
+  };
+
+  const directories = [repoRoot, ...getDirectories(repoRoot)];
 
   directories.forEach((dir) => {
-    test(`${dir} has README.md with a heading`, () => {
-      const filePath = path.join(__dirname, '..', dir, 'README.md');
+    const relativeDir = path.relative(repoRoot, dir) || '.';
+    test(`${relativeDir} has README.md with a heading`, () => {
+      const filePath = path.join(dir, 'README.md');
       expect(fs.existsSync(filePath)).toBe(true);
       const firstLine = fs.readFileSync(filePath, 'utf8').split('\n')[0];
       expect(firstLine.startsWith('# ')).toBe(true);


### PR DESCRIPTION
## Summary
- dynamically discover repo directories for README tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c41227be4832d907f2709b9a90808