### PR TITLE
Fix README test path exclusion

### DIFF
--- a/__tests__/readmeFiles.test.js
+++ b/__tests__/readmeFiles.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 describe('Repository documentation', () => {
   const repoRoot = path.join(__dirname, '..');
-  const excluded = new Set(['node_modules', '.git', 'coverage']);
+  const excluded = new Set(['node_modules', '.git', 'coverage', '.vscode']);
 
   const getDirectories = (dir) => {
     const entries = fs.readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
## Summary
- ensure `.vscode` folder doesn't break README checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c46965c40832db4f7250cb61c8bd2