### PR TITLE
Add Google Drive search command

### DIFF
--- a/__tests__/commands/drive.test.js
+++ b/__tests__/commands/drive.test.js
@@ -1,0 +1,14 @@
+jest.mock('../../commands/drive/search', () => jest.fn());
+
+const search = require('../../commands/drive/search');
+const drive = require('../../commands/drive');
+
+describe('drive command', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('routes to search subhandler', async () => {
+    const interaction = { options: { getSubcommand: jest.fn(() => 'search') } };
+    await drive.execute(interaction);
+    expect(search).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/drive/README.md
+++ b/__tests__/commands/drive/README.md
@@ -1,0 +1,3 @@
+# Drive Command Tests
+
+Unit tests for the `/drive` command subcommands, mocking Google Drive interactions.

--- a/__tests__/commands/drive/search.test.js
+++ b/__tests__/commands/drive/search.test.js
@@ -1,0 +1,47 @@
+jest.mock('../../../utils/googleDrive', () => {
+  const getClient = jest.fn();
+  return { getClient, __esModule: true, __mock: { getClient } };
+});
+
+jest.mock('googleapis', () => {
+  const listMock = jest.fn();
+  const getMock = jest.fn();
+  return { google: { drive: jest.fn(() => ({ files: { list: listMock, get: getMock } })) }, __esModule: true, __mock: { listMock, getMock } };
+});
+
+const { __mock: driveAuthMock } = require('../../../utils/googleDrive');
+const { __mock: gMock } = require('googleapis');
+const search = require('../../../commands/drive/search');
+
+describe('drive search', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies when file not found', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.listMock.mockResolvedValue({ data: { files: [] } });
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'file.txt') };
+    await search({ options, reply });
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No file'), ephemeral: true }));
+  });
+
+  test('downloads and sends file when found', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.listMock.mockResolvedValue({ data: { files: [{ id: '1', name: 'file.txt' }] } });
+    gMock.getMock.mockResolvedValue({ data: Buffer.from('abc') });
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'file.txt') };
+    await search({ options, reply });
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.objectContaining({ name: 'file.txt' })], ephemeral: true }));
+  });
+
+  test('handles errors gracefully', async () => {
+    driveAuthMock.getClient.mockRejectedValue(new Error('bad'));
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => 'file.txt') };
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await search({ options, reply });
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error'), ephemeral: true }));
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/utils/googleDrive.test.js
+++ b/__tests__/utils/googleDrive.test.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+jest.mock('googleapis', () => ({ google: {} }));
+
+jest.mock('google-auth-library', () => {
+  return {
+    JWT: jest.fn().mockImplementation(opts => ({ authorize: jest.fn().mockResolvedValue(), opts })),
+  };
+});
+
+const googleDrive = require('../../utils/googleDrive');
+const { JWT } = require('google-auth-library');
+
+const utilsDir = path.resolve(__dirname, '../../utils');
+const expectedKeyPath = path.join(utilsDir, '../google-credentials.json');
+
+describe('googleDrive getClient', () => {
+  it('authorizes and returns JWT client', async () => {
+    const client = await googleDrive.getClient();
+    expect(JWT).toHaveBeenCalledWith({ keyFile: expectedKeyPath, scopes: ['https://www.googleapis.com/auth/drive.readonly'] });
+    expect(client.authorize).toHaveBeenCalled();
+  });
+});

--- a/commands/drive.js
+++ b/commands/drive.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const searchHandler = require('./drive/search');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('drive')
+    .setDescription('Google Drive utilities.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .setDMPermission(false)
+    .addSubcommand(sub =>
+      sub.setName('search')
+        .setDescription('Search for a file by name.')
+        .addStringOption(opt =>
+          opt.setName('name').setDescription('File name to search for').setRequired(true)
+        )
+    ),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'search') {
+      return searchHandler(interaction);
+    }
+  },
+};

--- a/commands/drive/README.md
+++ b/commands/drive/README.md
@@ -1,0 +1,5 @@
+# /drive Subcommands
+
+Handlers for the `/drive` command.
+
+- `search.js` – `/drive search` for locating and downloading Google Drive files.

--- a/commands/drive/search.js
+++ b/commands/drive/search.js
@@ -1,0 +1,28 @@
+const { google } = require('googleapis');
+const driveAuth = require('../../utils/googleDrive');
+
+module.exports = async function search(interaction) {
+  const name = interaction.options.getString('name');
+  try {
+    const auth = await driveAuth.getClient();
+    const drive = google.drive({ version: 'v3', auth });
+    const listRes = await drive.files.list({
+      q: `name='${name.replace(/'/g, "\\'")}' and trashed=false`,
+      fields: 'files(id, name)',
+      pageSize: 1,
+    });
+    const file = (listRes.data.files || [])[0];
+    if (!file) {
+      return interaction.reply({ content: `❌ No file named **${name}** found.`, ephemeral: true });
+    }
+    const fileRes = await drive.files.get({ fileId: file.id, alt: 'media' }, { responseType: 'arraybuffer' });
+    return interaction.reply({
+      content: `📂 Found **${file.name}**`,
+      files: [{ attachment: Buffer.from(fileRes.data), name: file.name }],
+      ephemeral: true,
+    });
+  } catch (err) {
+    console.error('[drive:search] Error searching file:', err);
+    return interaction.reply({ content: '❌ Error searching Google Drive.', ephemeral: true });
+  }
+};

--- a/utils/README.md
+++ b/utils/README.md
@@ -7,3 +7,4 @@ Reusable helper modules supporting Google Calendar and scheduling features.
 - `scheduleFormatter.js` – formats events for display.
 - `scheduleEmbedBuilder.js` – builds rich embeds.
 - `importTrivia.js` – loads trivia questions into the database.
+- `googleDrive.js` – helper for Google Drive API authentication.

--- a/utils/googleDrive.js
+++ b/utils/googleDrive.js
@@ -1,0 +1,18 @@
+const { google } = require('googleapis');
+const path = require('path');
+const { JWT } = require('google-auth-library');
+
+const SERVICE_ACCOUNT_KEY_PATH = path.join(__dirname, '../google-credentials.json');
+const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
+
+const client = new JWT({
+  keyFile: SERVICE_ACCOUNT_KEY_PATH,
+  scopes: SCOPES,
+});
+
+module.exports = {
+  getClient: async () => {
+    await client.authorize();
+    return client;
+  },
+};


### PR DESCRIPTION
## Summary
- allow Google Drive API usage via `googleDrive.js`
- add `/drive search` command and subcommand implementation
- document Google Drive utilities
- test drive command and util

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c4ab28df8832d9d89fc6259689bd0