### PR TITLE
Fix drive search interaction timeout

### DIFF
--- a/__tests__/commands/drive/search.test.js
+++ b/__tests__/commands/drive/search.test.js
@@ -19,29 +19,35 @@ describe('drive search', () => {
   test('replies when file not found', async () => {
     driveAuthMock.getClient.mockResolvedValue({});
     gMock.listMock.mockResolvedValue({ data: { files: [] } });
-    const reply = jest.fn();
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
     const options = { getString: jest.fn(() => 'file.txt') };
-    await search({ options, reply });
-    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No file'), ephemeral: true }));
+    await search({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No file') }));
   });
 
   test('downloads and sends file when found', async () => {
     driveAuthMock.getClient.mockResolvedValue({});
     gMock.listMock.mockResolvedValue({ data: { files: [{ id: '1', name: 'file.txt' }] } });
     gMock.getMock.mockResolvedValue({ data: Buffer.from('abc') });
-    const reply = jest.fn();
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
     const options = { getString: jest.fn(() => 'file.txt') };
-    await search({ options, reply });
-    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.objectContaining({ name: 'file.txt' })], ephemeral: true }));
+    await search({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.objectContaining({ name: 'file.txt' })] }));
   });
 
   test('handles errors gracefully', async () => {
     driveAuthMock.getClient.mockRejectedValue(new Error('bad'));
-    const reply = jest.fn();
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
     const options = { getString: jest.fn(() => 'file.txt') };
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    await search({ options, reply });
-    expect(reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error'), ephemeral: true }));
+    await search({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error') }));
     errorSpy.mockRestore();
   });
 });

--- a/commands/drive/search.js
+++ b/commands/drive/search.js
@@ -3,6 +3,7 @@ const driveAuth = require('../../utils/googleDrive');
 
 module.exports = async function search(interaction) {
   const name = interaction.options.getString('name');
+  await interaction.deferReply({ ephemeral: true });
   try {
     const auth = await driveAuth.getClient();
     const drive = google.drive({ version: 'v3', auth });
@@ -13,16 +14,15 @@ module.exports = async function search(interaction) {
     });
     const file = (listRes.data.files || [])[0];
     if (!file) {
-      return interaction.reply({ content: `❌ No file named **${name}** found.`, ephemeral: true });
+      return interaction.editReply({ content: `❌ No file named **${name}** found.` });
     }
     const fileRes = await drive.files.get({ fileId: file.id, alt: 'media' }, { responseType: 'arraybuffer' });
-    return interaction.reply({
+    return interaction.editReply({
       content: `📂 Found **${file.name}**`,
       files: [{ attachment: Buffer.from(fileRes.data), name: file.name }],
-      ephemeral: true,
     });
   } catch (err) {
     console.error('[drive:search] Error searching file:', err);
-    return interaction.reply({ content: '❌ Error searching Google Drive.', ephemeral: true });
+    return interaction.editReply({ content: '❌ Error searching Google Drive.' });
   }
 };


### PR DESCRIPTION
## Summary
- prevent interaction timeout in `/drive search`
- update drive search tests for defer/edit reply

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683c4cefb8c4832da68e07cf2a8d6962