### PR TITLE
Add Google Drive grep subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A multifunctional Discord bot for the **New Mexico Boys State** program 🇺🇸
 - 🛠️ **Admin Utilities:** Test database & calendar connectivity; sync models
 - ✨ Slash command support via `discord.js` v14
 - 🔌 Modular command and interaction handlers for easy extension
+- 📂 **Google Drive Search:** Find files by name or contents
 
 ## 🏗️ Project Structure
 

--- a/__tests__/commands/drive.test.js
+++ b/__tests__/commands/drive.test.js
@@ -1,6 +1,8 @@
 jest.mock('../../commands/drive/search', () => jest.fn());
+jest.mock('../../commands/drive/grep', () => jest.fn());
 
 const search = require('../../commands/drive/search');
+const grep = require('../../commands/drive/grep');
 const drive = require('../../commands/drive');
 
 describe('drive command', () => {
@@ -10,5 +12,11 @@ describe('drive command', () => {
     const interaction = { options: { getSubcommand: jest.fn(() => 'search') } };
     await drive.execute(interaction);
     expect(search).toHaveBeenCalledWith(interaction);
+  });
+
+  test('routes to grep subhandler', async () => {
+    const interaction = { options: { getSubcommand: jest.fn(() => 'grep') } };
+    await drive.execute(interaction);
+    expect(grep).toHaveBeenCalledWith(interaction);
   });
 });

--- a/__tests__/commands/drive/grep.test.js
+++ b/__tests__/commands/drive/grep.test.js
@@ -1,0 +1,51 @@
+jest.mock('../../../utils/googleDrive', () => {
+  const getClient = jest.fn();
+  return { getClient, __esModule: true, __mock: { getClient } };
+});
+
+jest.mock('googleapis', () => {
+  const listMock = jest.fn();
+  return { google: { drive: jest.fn(() => ({ files: { list: listMock } })) }, __esModule: true, __mock: { listMock } };
+});
+
+const { __mock: driveAuthMock } = require('../../../utils/googleDrive');
+const { __mock: gMock } = require('googleapis');
+const grep = require('../../../commands/drive/grep');
+
+describe('drive grep', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies when no files match', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.listMock.mockResolvedValue({ data: { files: [] } });
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const options = { getString: jest.fn(() => 'foo') };
+    await grep({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No files') }));
+  });
+
+  test('lists matching files', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.listMock.mockResolvedValue({ data: { files: [{ id: '1', name: 'a.txt' }, { id: '2', name: 'b.txt' }] } });
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const options = { getString: jest.fn(() => 'foo') };
+    await grep({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('a.txt') }));
+  });
+
+  test('handles errors gracefully', async () => {
+    driveAuthMock.getClient.mockRejectedValue(new Error('bad'));
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const options = { getString: jest.fn(() => 'foo') };
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await grep({ options, deferReply, editReply });
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error') }));
+    errorSpy.mockRestore();
+  });
+});

--- a/commands/drive.js
+++ b/commands/drive.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const searchHandler = require('./drive/search');
+const grepHandler = require('./drive/grep');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -13,11 +14,21 @@ module.exports = {
         .addStringOption(opt =>
           opt.setName('name').setDescription('File name to search for').setRequired(true)
         )
+    )
+    .addSubcommand(sub =>
+      sub.setName('grep')
+        .setDescription('Search for text within files.')
+        .addStringOption(opt =>
+          opt.setName('query').setDescription('Text to search for').setRequired(true)
+        )
     ),
   async execute(interaction) {
     const sub = interaction.options.getSubcommand();
     if (sub === 'search') {
       return searchHandler(interaction);
+    }
+    if (sub === 'grep') {
+      return grepHandler(interaction);
     }
   },
 };

--- a/commands/drive/README.md
+++ b/commands/drive/README.md
@@ -3,3 +3,4 @@
 Handlers for the `/drive` command.
 
 - `search.js` – `/drive search` for locating and downloading Google Drive files.
+- `grep.js` – `/drive grep` to search for files containing specific text.

--- a/commands/drive/grep.js
+++ b/commands/drive/grep.js
@@ -1,0 +1,25 @@
+const { google } = require('googleapis');
+const driveAuth = require('../../utils/googleDrive');
+
+module.exports = async function grep(interaction) {
+  const query = interaction.options.getString('query');
+  await interaction.deferReply({ ephemeral: true });
+  try {
+    const auth = await driveAuth.getClient();
+    const drive = google.drive({ version: 'v3', auth });
+    const listRes = await drive.files.list({
+      q: `fullText contains '${query.replace(/'/g, "\\'")}' and trashed=false`,
+      fields: 'files(id, name)',
+      pageSize: 5,
+    });
+    const files = listRes.data.files || [];
+    if (!files.length) {
+      return interaction.editReply({ content: `❌ No files contain **${query}**.` });
+    }
+    const list = files.map(f => `• ${f.name}`).join('\n');
+    return interaction.editReply({ content: `📄 Files containing **${query}**:\n${list}` });
+  } catch (err) {
+    console.error('[drive:grep] Error searching contents:', err);
+    return interaction.editReply({ content: '❌ Error searching Google Drive.' });
+  }
+};


### PR DESCRIPTION
## Summary
- add `/drive grep` command to search Google Drive file contents
- document new subcommand
- test the handler and command routing
- mention drive search capability in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c4ddb4f6c832dbdfb75d84bd9c9bd