### PR TITLE
Add calendar notification toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A multifunctional Discord bot for the **New Mexico Boys State** program 🇺🇸
 - ✨ Slash command support via `discord.js` v14
 - 🔌 Modular command and interaction handlers for easy extension
 - 📂 **Google Drive Search:** Find files by name or contents
+- 🔕 **Toggle Schedule Notifications**: Pause and resume calendar update posts
 
 ## 🏗️ Project Structure
 

--- a/__tests__/commands/calendar.test.js
+++ b/__tests__/commands/calendar.test.js
@@ -5,6 +5,7 @@ jest.mock('../../commands/calendar/list', () => jest.fn());
 jest.mock('../../commands/calendar/set-channel', () => jest.fn());
 jest.mock('../../commands/calendar/list-channels', () => jest.fn());
 jest.mock('../../commands/calendar/remove-channel', () => jest.fn());
+jest.mock('../../commands/calendar/toggle-notifications', () => jest.fn());
 jest.mock('../../commands/calendar/set-daterange', () => jest.fn());
 jest.mock('../../commands/calendar/link', () => jest.fn());
 
@@ -15,6 +16,7 @@ const list = require('../../commands/calendar/list');
 const setChannel = require('../../commands/calendar/set-channel');
 const listChannels = require('../../commands/calendar/list-channels');
 const removeChannel = require('../../commands/calendar/remove-channel');
+const toggleNotifications = require('../../commands/calendar/toggle-notifications');
 const setDaterange = require('../../commands/calendar/set-daterange');
 const link = require('../../commands/calendar/link');
 const calendar = require('../../commands/calendar');
@@ -33,6 +35,7 @@ describe('calendar command', () => {
       'set-channel': setChannel,
       'list-channels': listChannels,
       'remove-channel': removeChannel,
+      'toggle-notifications': toggleNotifications,
       'set-daterange': setDaterange,
       'link': link,
     };

--- a/__tests__/commands/calendar/toggle_notifications.test.js
+++ b/__tests__/commands/calendar/toggle_notifications.test.js
@@ -1,0 +1,28 @@
+jest.mock('../../../db/models/NotificationChannel', () => {
+  const findOne = jest.fn();
+  return { findOne, __esModule: true, __mock: { findOne } };
+});
+
+const { __mock } = require('../../../db/models/NotificationChannel');
+const findOne = __mock.findOne;
+const handler = require('../../../commands/calendar/toggle-notifications');
+
+describe('calendar toggle-notifications', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('no channel configured', async () => {
+    findOne.mockResolvedValue(null);
+    const reply = jest.fn();
+    await handler({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('toggles setting', async () => {
+    const save = jest.fn();
+    findOne.mockResolvedValue({ enabled: true, save });
+    const reply = jest.fn();
+    await handler({ reply }, 'g');
+    expect(save).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/db/models/NotificationChannel.test.js
+++ b/__tests__/db/models/NotificationChannel.test.js
@@ -14,6 +14,7 @@ describe('NotificationChannel model', () => {
       expect.objectContaining({
         guildId: expect.anything(),
         channelId: expect.anything(),
+        enabled: expect.anything(),
       }),
       expect.objectContaining({ tableName: 'notification_channels' })
     );

--- a/__tests__/utils/calendarPoller.test.js
+++ b/__tests__/utils/calendarPoller.test.js
@@ -131,4 +131,17 @@ describe('calendarPoller', () => {
     expect(staleDestroy).toHaveBeenCalled();
     expect(send).toHaveBeenCalled();
   });
+
+  it('does not notify when channel disabled', async () => {
+    CalendarConfig.findAll.mockResolvedValue([{ guildId: '1', calendarId: 'cal', startDate: '2025-06-01', endDate: '2025-06-10' }]);
+    CalendarEvent.findOne.mockResolvedValue(undefined);
+    CalendarEvent.findAll.mockResolvedValue([]);
+    NotificationChannel.findOne.mockResolvedValue({ channelId: 'chan', enabled: false });
+    const send = jest.fn();
+    mockClient.channels.fetch.mockResolvedValue({ send });
+
+    await pollCalendars(mockClient);
+
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/commands/calendar.js
+++ b/commands/calendar.js
@@ -8,6 +8,7 @@ const listChannelsHandler = require('./calendar/list-channels');
 const removeChannelHandler = require('./calendar/remove-channel');
 const setDateRangeHandler = require('./calendar/set-daterange');
 const calendarLinkHandler = require('./calendar/link');
+const toggleNotificationsHandler = require('./calendar/toggle-notifications');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -55,6 +56,10 @@ module.exports = {
               .setRequired(true)
          )
     )
+    .addSubcommand(sub =>
+      sub.setName('toggle-notifications')
+         .setDescription('Toggles schedule update notifications on or off')
+    )
     .addSubcommand(subcommand =>
       subcommand
         .setName('set-daterange')
@@ -86,6 +91,7 @@ module.exports = {
     if (sub === 'set-channel') return setChannelHandler(interaction, guildId);
     if (sub === 'list-channels') return listChannelsHandler(interaction, guildId);
     if (sub === 'remove-channel') return removeChannelHandler(interaction, guildId);
+    if (sub === 'toggle-notifications') return toggleNotificationsHandler(interaction, guildId);
     if (sub === 'set-daterange') return setDateRangeHandler(interaction, guildId);
     if (sub === 'link') return calendarLinkHandler(interaction, guildId);
   },

--- a/commands/calendar/README.md
+++ b/commands/calendar/README.md
@@ -8,6 +8,7 @@ Each file implements a subcommand for managing Google Calendar integration:
 - `edit.js` → `/calendar edit`
 - `remove.js` → `/calendar remove`
 - `list.js` → `/calendar list`
+- `toggle-notifications.js` → `/calendar toggle-notifications`
 
 All subcommands are built using Discord.js v14's SlashCommandBuilder.
 

--- a/commands/calendar/toggle-notifications.js
+++ b/commands/calendar/toggle-notifications.js
@@ -1,0 +1,41 @@
+const NotificationChannel = require('../../db/models/NotificationChannel');
+
+module.exports = async function toggleNotifications(interaction, guildId) {
+  try {
+    const config = await NotificationChannel.findOne({ where: { guildId } });
+    if (!config) {
+      return await interaction.reply({
+        embeds: [{
+          title: '❌ No Notification Channel Configured',
+          description: 'Use `/calendar set-channel` first to specify a channel.',
+          color: 0xFF0000,
+        }],
+        ephemeral: true,
+      });
+    }
+
+    config.enabled = !config.enabled;
+    await config.save();
+
+    await interaction.reply({
+      embeds: [{
+        title: config.enabled ? '✅ Notifications Enabled' : '🔕 Notifications Disabled',
+        description: config.enabled
+          ? 'Schedule update notifications will be sent.'
+          : 'No schedule update notifications will be sent.',
+        color: config.enabled ? 0x2ECC71 : 0xCCCCCC,
+      }],
+      ephemeral: true,
+    });
+  } catch (error) {
+    console.error('[calendar:toggle-notifications] ❌ Error:', error);
+    await interaction.reply({
+      embeds: [{
+        title: '❌ Error Toggling Notifications',
+        description: `An unexpected error occurred:\n\`${error.message}\``,
+        color: 0xFF0000,
+      }],
+      ephemeral: true,
+    });
+  }
+};

--- a/db/models/NotificationChannel.js
+++ b/db/models/NotificationChannel.js
@@ -12,6 +12,12 @@ const NotificationChannel = sequelize.define('NotificationChannel', {
     allowNull: false,
     comment: 'Channel ID to send notifications to',
   },
+  enabled: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+    comment: 'Whether calendar notifications are enabled',
+  },
 }, {
   tableName: 'notification_channels',
   timestamps: false,

--- a/utils/calendarPoller.js
+++ b/utils/calendarPoller.js
@@ -97,7 +97,9 @@ async function pollCalendars(client) {
         const summary = apiEvent.summary || '';
 
         const notifConfig = await NotificationChannel.findOne({ where: { guildId } });
-        const channel = notifConfig ? await client.channels.fetch(notifConfig.channelId).catch(() => null) : null;
+        const channel = notifConfig && notifConfig.enabled !== false
+          ? await client.channels.fetch(notifConfig.channelId).catch(() => null)
+          : null;
 
         if (!existing) {
           await CalendarEvent.create({ guildId, calendarId, eventId: apiEvent.id, summary, location, startTime, endTime });
@@ -136,7 +138,9 @@ async function pollCalendars(client) {
       for (const stale of staleEvents) {
         await stale.destroy();
         const notifConfig = await NotificationChannel.findOne({ where: { guildId } });
-        const channel = notifConfig ? await client.channels.fetch(notifConfig.channelId).catch(() => null) : null;
+        const channel = notifConfig && notifConfig.enabled !== false
+          ? await client.channels.fetch(notifConfig.channelId).catch(() => null)
+          : null;
         if (channel) {
           const embed = buildEventEmbed('cancelled', stale.summary, stale.startTime || new Date(), stale.location);
           await channel.send({ embeds: [embed] });


### PR DESCRIPTION
## Summary
- allow calendar notifications to be enabled/disabled
- check enabled flag in poller
- document new `/calendar toggle-notifications` subcommand
- test notification toggle and poller behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c54e2250c832da5e6359ad0b40a52