### PR TITLE
Enable downloading from /drive grep results

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A multifunctional Discord bot for the **New Mexico Boys State** program 🇺🇸
 - 🛠️ **Admin Utilities:** Test database & calendar connectivity; sync models
 - ✨ Slash command support via `discord.js` v14
 - 🔌 Modular command and interaction handlers for easy extension
-- 📂 **Google Drive Search:** Find files by name or contents
+- 📂 **Google Drive Search:** Find files by name or contents and download them through the bot
 
 ## 🏗️ Project Structure
 

--- a/__tests__/handlers/selectMenus/driveGrepSelect.test.js
+++ b/__tests__/handlers/selectMenus/driveGrepSelect.test.js
@@ -1,0 +1,65 @@
+jest.mock('../../../utils/googleDrive', () => {
+  const getClient = jest.fn();
+  return { getClient, __esModule: true, __mock: { getClient } };
+});
+
+jest.mock('googleapis', () => {
+  const getMock = jest.fn();
+  return { google: { drive: jest.fn(() => ({ files: { get: getMock } })) }, __esModule: true, __mock: { getMock } };
+});
+
+const { __mock: driveAuthMock } = require('../../../utils/googleDrive');
+const { __mock: gMock } = require('googleapis');
+const handler = require('../../../handlers/selectMenus/driveGrepSelect');
+
+describe('driveGrepSelect', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('rejects wrong user', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      customId: 'drive_grep_select_1',
+      user: { id: '2' },
+      values: ['x'],
+      reply,
+    };
+    await handler(interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('downloads selected file', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.getMock
+      .mockResolvedValueOnce({ data: { name: 'file.txt' } })
+      .mockResolvedValueOnce({ data: Buffer.from('abc') });
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const interaction = {
+      customId: 'drive_grep_select_1',
+      user: { id: '1' },
+      values: ['fileId'],
+      deferReply,
+      editReply,
+    };
+    await handler(interaction);
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.objectContaining({ name: 'file.txt' })] }));
+  });
+
+  test('handles errors gracefully', async () => {
+    driveAuthMock.getClient.mockRejectedValue(new Error('bad'));
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const interaction = {
+      customId: 'drive_grep_select_1',
+      user: { id: '1' },
+      values: ['fileId'],
+      deferReply,
+      editReply,
+    };
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await handler(interaction);
+    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error') }));
+    errorSpy.mockRestore();
+  });
+});

--- a/commands/drive/README.md
+++ b/commands/drive/README.md
@@ -3,4 +3,4 @@
 Handlers for the `/drive` command.
 
 - `search.js` – `/drive search` for locating and downloading Google Drive files.
-- `grep.js` – `/drive grep` to recursively search file contents and return download links.
+- `grep.js` – `/drive grep` to search file contents and select a file to download.

--- a/commands/drive/grep.js
+++ b/commands/drive/grep.js
@@ -1,4 +1,5 @@
 const { google } = require('googleapis');
+const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 const driveAuth = require('../../utils/googleDrive');
 
 module.exports = async function grep(interaction) {
@@ -23,10 +24,18 @@ module.exports = async function grep(interaction) {
     if (!files.length) {
       return interaction.editReply({ content: `❌ No files contain **${query}**.` });
     }
-    const list = files
-      .map(f => `• [${f.name}](https://drive.google.com/uc?id=${f.id}&export=download)`) 
-      .join('\n');
-    return interaction.editReply({ content: `📄 Files containing **${query}**:\n${list}` });
+
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId(`drive_grep_select_${interaction.user.id}`)
+      .setPlaceholder('Select a file to download')
+      .addOptions(files.map(f => ({ label: f.name, value: f.id })));
+
+    const row = new ActionRowBuilder().addComponents(menu);
+
+    return interaction.editReply({
+      content: `📄 Select a file containing **${query}**:`,
+      components: [row],
+    });
   } catch (err) {
     console.error('[drive:grep] Error searching contents:', err);
     return interaction.editReply({ content: '❌ Error searching Google Drive.' });

--- a/handlers/selectMenus/driveGrepSelect.js
+++ b/handlers/selectMenus/driveGrepSelect.js
@@ -1,0 +1,34 @@
+const { google } = require('googleapis');
+const driveAuth = require('../../utils/googleDrive');
+
+module.exports = async function driveGrepSelect(interaction) {
+  const parts = interaction.customId.split('_');
+  const action = parts.slice(0, -1).join('_');
+  const userId = parts.at(-1);
+
+  if (action !== 'drive_grep_select') return;
+
+  if (interaction.user.id !== userId) {
+    return interaction.reply({ content: 'This select menu wasn\'t meant for you.', ephemeral: true });
+  }
+
+  const fileId = interaction.values[0];
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const auth = await driveAuth.getClient();
+    const drive = google.drive({ version: 'v3', auth });
+    const metaRes = await drive.files.get({ fileId, fields: 'name' });
+    const dataRes = await drive.files.get(
+      { fileId, alt: 'media' },
+      { responseType: 'arraybuffer' }
+    );
+    await interaction.editReply({
+      content: `📥 Downloading **${metaRes.data.name}**`,
+      files: [{ attachment: Buffer.from(dataRes.data), name: metaRes.data.name }],
+    });
+  } catch (err) {
+    console.error('[drive:grep_select] Error downloading file:', err);
+    await interaction.editReply({ content: '❌ Error downloading file.' });
+  }
+};


### PR DESCRIPTION
## Summary
- add interactive file selection for `/drive grep`
- implement `driveGrepSelect` handler to fetch the chosen file
- update docs and tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c56d726f0832d97eb687a1db4bffd