### PR TITLE
Fix grep duplicates

### DIFF
--- a/__tests__/commands/drive/grep.test.js
+++ b/__tests__/commands/drive/grep.test.js
@@ -47,6 +47,21 @@ describe('drive grep', () => {
     expect(StringSelectMenuBuilder.mock.instances[0].data.customId).toBe('drive_grep_select_u1');
   });
 
+  test('deduplicates files with same id', async () => {
+    driveAuthMock.getClient.mockResolvedValue({});
+    gMock.listMock.mockResolvedValue({ data: { files: [
+      { id: '1', name: 'a.txt' },
+      { id: '1', name: 'copy of a.txt' },
+      { id: '2', name: 'b.txt' },
+    ] } });
+    const deferReply = jest.fn();
+    const editReply = jest.fn();
+    const options = { getString: jest.fn(() => 'foo') };
+    const user = { id: 'u2' };
+    await grep({ options, deferReply, editReply, user });
+    expect(StringSelectMenuBuilder.mock.instances[0].data.options).toHaveLength(2);
+  });
+
   test('paginates through results', async () => {
     driveAuthMock.getClient.mockResolvedValue({});
     gMock.listMock

--- a/commands/drive/grep.js
+++ b/commands/drive/grep.js
@@ -25,10 +25,19 @@ module.exports = async function grep(interaction) {
       return interaction.editReply({ content: `❌ No files contain **${query}**.` });
     }
 
+    const unique = [];
+    const seen = new Set();
+    for (const file of files) {
+      if (!seen.has(file.id)) {
+        unique.push(file);
+        seen.add(file.id);
+      }
+    }
+
     const menu = new StringSelectMenuBuilder()
       .setCustomId(`drive_grep_select_${interaction.user.id}`)
       .setPlaceholder('Select a file to download')
-      .addOptions(files.map(f => ({ label: f.name, value: f.id })));
+      .addOptions(unique.map(f => ({ label: f.name, value: f.id })));
 
     const row = new ActionRowBuilder().addComponents(menu);
 


### PR DESCRIPTION
## Summary
- deduplicate Google Drive results before creating select menu
- test duplicate removal for /drive grep subcommand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c5cdaec54832d986b3ab5923ded93