### PR TITLE
Add daily schedule poster

### DIFF
--- a/__tests__/commands/set_schedule_channel.test.js
+++ b/__tests__/commands/set_schedule_channel.test.js
@@ -1,0 +1,35 @@
+jest.mock('../../db/models', () => ({
+  ScheduleChannel: { upsert: jest.fn() },
+  __esModule: true
+}));
+const { ScheduleChannel } = require('../../db/models');
+const upsert = ScheduleChannel.upsert;
+const cmd = require('../../commands/set_schedule_channel');
+
+describe('set_schedule_channel command', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('requires admin', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      member: { permissions: { has: () => false } },
+      reply
+    };
+    await cmd.execute(interaction);
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('sets channel', async () => {
+    upsert.mockResolvedValue();
+    const reply = jest.fn();
+    const interaction = {
+      member: { permissions: { has: () => true } },
+      options: { getChannel: jest.fn(() => ({ id: '1' })) },
+      guildId: 'g',
+      reply
+    };
+    await cmd.execute(interaction);
+    expect(upsert).toHaveBeenCalledWith({ guildId: 'g', channelId: '1' });
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/__tests__/db/models/ScheduleChannel.test.js
+++ b/__tests__/db/models/ScheduleChannel.test.js
@@ -1,0 +1,23 @@
+const mockDefine = jest.fn().mockReturnValue({ name: 'ScheduleChannel' });
+jest.mock('../../../db/index', () => ({ define: mockDefine }));
+
+describe('ScheduleChannel model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('defines ScheduleChannel schema', () => {
+    const model = require('../../../db/models/ScheduleChannel');
+    expect(mockDefine).toHaveBeenCalledWith(
+      'ScheduleChannel',
+      expect.objectContaining({
+        guildId: expect.anything(),
+        channelId: expect.anything(),
+        messageId: expect.anything(),
+      }),
+      expect.objectContaining({ tableName: 'schedule_channels' })
+    );
+    expect(model).toEqual({ name: 'ScheduleChannel' });
+  });
+});

--- a/__tests__/db/models/index.test.js
+++ b/__tests__/db/models/index.test.js
@@ -5,6 +5,7 @@ jest.mock('../../../db/models/CalendarConfig', () => ({ name: 'CalendarConfig', 
 jest.mock('../../../db/models/CalendarEvent', () => ({ name: 'CalendarEvent', associate: jest.fn() }));
 jest.mock('../../../db/models/NotificationChannel', () => ({ name: 'NotificationChannel', associate: jest.fn() }));
 jest.mock('../../../db/models/TriviaQuestion', () => ({ name: 'TriviaQuestion', associate: jest.fn() }));
+jest.mock('../../../db/models/ScheduleChannel', () => ({ name: 'ScheduleChannel', associate: jest.fn() }));
 
 describe('models/index.js', () => {
   beforeEach(() => {

--- a/__tests__/utils/dailySchedulePoster.test.js
+++ b/__tests__/utils/dailySchedulePoster.test.js
@@ -1,0 +1,46 @@
+jest.mock('../../db/models', () => ({
+  ScheduleChannel: { findOne: jest.fn(), findAll: jest.fn() },
+  CalendarEvent: { findAll: jest.fn() },
+  __esModule: true
+}));
+
+const { ScheduleChannel, CalendarEvent } = require('../../db/models');
+const { postScheduleForToday, isTodayMountain } = require('../../utils/dailySchedulePoster');
+
+const mockChannel = () => ({
+  send: jest.fn().mockResolvedValue({ id: 'm1' }),
+  messages: { fetch: jest.fn().mockResolvedValue({ edit: jest.fn() }) }
+});
+
+describe('dailySchedulePoster', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('isTodayMountain detects same day', () => {
+    const now = new Date();
+    expect(isTodayMountain(now)).toBe(true);
+  });
+
+  test('posts new message when none exists', async () => {
+    ScheduleChannel.findOne.mockResolvedValue({ guildId: 'g', channelId: '1', save: jest.fn() });
+    CalendarEvent.findAll.mockResolvedValue([]);
+    const client = { channels: { fetch: jest.fn().mockResolvedValue(mockChannel()) } };
+    await postScheduleForToday(client, 'g');
+    expect(client.channels.fetch).toHaveBeenCalledWith('1');
+  });
+
+  test('edits existing message', async () => {
+    const edit = jest.fn();
+    ScheduleChannel.findOne.mockResolvedValue({ guildId: 'g', channelId: '1', messageId: 'm1', save: jest.fn() });
+    CalendarEvent.findAll.mockResolvedValue([]);
+    const client = {
+      channels: {
+        fetch: jest.fn().mockResolvedValue({
+          messages: { fetch: jest.fn().mockResolvedValue({ edit }) },
+          send: jest.fn()
+        })
+      }
+    };
+    await postScheduleForToday(client, 'g');
+    expect(edit).toHaveBeenCalled();
+  });
+});

--- a/bot.js
+++ b/bot.js
@@ -4,6 +4,7 @@ const { Client, GatewayIntentBits, Collection } = require('discord.js');
 const commandHandler = require('./handlers/commandHandler');
 const interactionHandler = require('./handlers/interactionHandler');
 const { pollCalendars } = require('./utils/calendarPoller');
+const { scheduleDailyTask, postScheduleForToday, isTodayMountain } = require('./utils/dailySchedulePoster');
 
 const client = new Client({
   intents: [
@@ -30,10 +31,15 @@ client.login(process.env.DISCORD_TOKEN)
 client.once('ready', async () => {
   console.log(`🎉 Logged in as ${client.user.tag}`);
   await commandHandler(client);
+  scheduleDailyTask(client);
 
   // Start polling every 5 seconds
   setInterval(() => {
-    pollCalendars(client).catch(err => console.error('Poller error:', err));
+    pollCalendars(client, async (guildId, eventDate) => {
+      if (isTodayMountain(eventDate)) {
+        await postScheduleForToday(client, guildId);
+      }
+    }).catch(err => console.error('Poller error:', err));
   }, 5000);
 });
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -10,6 +10,7 @@ Example:
 
 - `calendar.js` → `/calendar` command
 - `calendar/` → holds `set.js`, `edit.js`, `remove.js`, `list.js` for `/calendar set`, `/calendar edit`, etc.
+- `set_schedule_channel.js` → `/set_schedule_channel` command for daily schedule posts
 
 When adding a new command:
 

--- a/commands/set_schedule_channel.js
+++ b/commands/set_schedule_channel.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const ScheduleChannel = require('../db/models').ScheduleChannel;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('set_schedule_channel')
+    .setDescription('Sets the channel used for daily schedule posts.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .setDMPermission(false)
+    .addChannelOption(opt =>
+      opt.setName('channel')
+        .setDescription('Channel for daily schedule messages')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has('Administrator')) {
+      return interaction.reply({
+        embeds: [{ title: '🚫 Permission Denied', description: 'You must be an administrator to use this command.', color: 0xFF0000 }],
+        ephemeral: true,
+      });
+    }
+
+    const channel = interaction.options.getChannel('channel');
+    const guildId = interaction.guildId;
+
+    await ScheduleChannel.upsert({ guildId, channelId: channel.id });
+
+    await interaction.reply({
+      embeds: [{ title: '✅ Daily Schedule Channel Set', description: `Daily schedule updates will post in <#${channel.id}>.`, color: 0x2ECC71 }],
+      ephemeral: true,
+    });
+  }
+};

--- a/db/models/README.md
+++ b/db/models/README.md
@@ -5,6 +5,9 @@ This folder contains Sequelize model definitions for the BoysStateBot database.
 Current models:
 
 - `CalendarConfig.js` → stores configured Google Calendar IDs for each guild.
+- `CalendarEvent.js` → cached events for diffing against Google Calendar.
+- `NotificationChannel.js` → channels used for schedule change notifications.
+- `ScheduleChannel.js` → channels where the daily schedule embed is posted.
 - `TriviaQuestion.js` → stores trivia questions and answers for the `/nmtrivia` command.
 
 Each model exports a function that defines the schema and associations.

--- a/db/models/ScheduleChannel.js
+++ b/db/models/ScheduleChannel.js
@@ -1,0 +1,25 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../index');
+
+const ScheduleChannel = sequelize.define('ScheduleChannel', {
+  guildId: {
+    type: DataTypes.STRING,
+    primaryKey: true,
+    comment: 'Discord guild ID'
+  },
+  channelId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    comment: 'Channel ID for daily schedule posts'
+  },
+  messageId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    comment: 'Last posted schedule message ID'
+  }
+}, {
+  tableName: 'schedule_channels',
+  timestamps: false
+});
+
+module.exports = ScheduleChannel;

--- a/utils/README.md
+++ b/utils/README.md
@@ -8,3 +8,4 @@ Reusable helper modules supporting Google Calendar and scheduling features.
 - `scheduleEmbedBuilder.js` – builds rich embeds.
 - `importTrivia.js` – loads trivia questions into the database.
 - `googleDrive.js` – helper for Google Drive API authentication.
+- `dailySchedulePoster.js` – posts the day's schedule to a configured channel.

--- a/utils/calendarPoller.js
+++ b/utils/calendarPoller.js
@@ -52,7 +52,7 @@ function buildEventEmbed(type, summary, startTime, location, changes = {}) {
   return embed;
 }
 
-async function pollCalendars(client) {
+async function pollCalendars(client, onChange) {
   if (!client || !client.channels || typeof client.channels.fetch !== 'function') {
     throw new Error('[pollCalendars] A valid Discord client must be passed to pollCalendars(client)');
   }
@@ -107,6 +107,7 @@ async function pollCalendars(client) {
             const embed = buildEventEmbed('added', summary, startTime, location);
             await channel.send({ embeds: [embed] });
           }
+          if (onChange) await onChange(guildId, startTime);
         } else if (existing.startTime.getTime() !== startTime.getTime() || existing.location !== location) {
 
           const changes = {};
@@ -127,6 +128,7 @@ async function pollCalendars(client) {
             const embed = buildEventEmbed('updated', summary, startTime, location, changes);
             await channel.send({ embeds: [embed] });
           }
+          if (onChange) await onChange(guildId, startTime);
         }
       }
 
@@ -145,6 +147,7 @@ async function pollCalendars(client) {
           const embed = buildEventEmbed('cancelled', stale.summary, stale.startTime || new Date(), stale.location);
           await channel.send({ embeds: [embed] });
         }
+        if (onChange) await onChange(guildId, stale.startTime);
       }
 
     } catch (err) {

--- a/utils/dailySchedulePoster.js
+++ b/utils/dailySchedulePoster.js
@@ -1,0 +1,72 @@
+const { Op } = require('sequelize');
+const { ScheduleChannel, CalendarEvent } = require('../db/models');
+const formatScheduleList = require('./scheduleFormatter');
+const buildScheduleEmbed = require('./scheduleEmbedBuilder');
+
+function getTimezoneOffset(zone, date = new Date()) {
+  const local = new Date(date.toLocaleString('en-US', { timeZone: zone }));
+  return date.getTime() - local.getTime();
+}
+
+function isTodayMountain(date) {
+  const offset = getTimezoneOffset('America/Denver');
+  const nowMt = new Date(Date.now() - offset);
+  const dateMt = new Date(date.getTime() - offset);
+  return nowMt.getFullYear() === dateMt.getFullYear() &&
+    nowMt.getMonth() === dateMt.getMonth() &&
+    nowMt.getDate() === dateMt.getDate();
+}
+
+async function postScheduleForToday(client, guildId) {
+  const config = await ScheduleChannel.findOne({ where: { guildId } });
+  if (!config) return;
+  const channel = await client.channels.fetch(config.channelId).catch(() => null);
+  if (!channel) return;
+
+  const offset = getTimezoneOffset('America/Denver');
+  const nowMt = new Date(Date.now() - offset);
+  const startUtc = new Date(Date.UTC(nowMt.getFullYear(), nowMt.getMonth(), nowMt.getDate(), 0, 0, 0));
+  const endUtc = new Date(Date.UTC(nowMt.getFullYear(), nowMt.getMonth(), nowMt.getDate(), 23, 59, 59, 999));
+
+  const events = await CalendarEvent.findAll({
+    where: { guildId, startTime: { [Op.between]: [startUtc, endUtc] } },
+    order: [['startTime', 'ASC']],
+  });
+
+  const description = events.length ? formatScheduleList(events) : 'No events scheduled for today.';
+  const embed = buildScheduleEmbed("Today's Schedule", description, events.length ? 0x2ECC71 : 0xCCCCCC);
+
+  if (config.messageId) {
+    const message = await channel.messages.fetch(config.messageId).catch(() => null);
+    if (message) {
+      await message.edit({ embeds: [embed] });
+      return;
+    }
+  }
+  const sent = await channel.send({ embeds: [embed] });
+  config.messageId = sent.id;
+  await config.save();
+}
+
+function scheduleDailyTask(client) {
+  async function scheduleNext() {
+    const now = new Date();
+    const offset = getTimezoneOffset('America/Denver', now);
+    const mtNow = new Date(now.getTime() - offset);
+    let mtNext = new Date(mtNow);
+    mtNext.setHours(4, 0, 0, 0);
+    if (mtNow >= mtNext) mtNext.setDate(mtNext.getDate() + 1);
+    const nextUtc = new Date(mtNext.getTime() + offset);
+    const delay = nextUtc.getTime() - now.getTime();
+    setTimeout(async () => {
+      const guilds = await ScheduleChannel.findAll();
+      for (const cfg of guilds) {
+        await postScheduleForToday(client, cfg.guildId);
+      }
+      scheduleNext();
+    }, delay);
+  }
+  scheduleNext();
+}
+
+module.exports = { postScheduleForToday, scheduleDailyTask, isTodayMountain };


### PR DESCRIPTION
## Summary
- add `ScheduleChannel` model and docs
- create `/set_schedule_channel` command
- post daily schedule at 4 AM Mountain time
- update daily message when schedule changes
- document utilities
- tests for new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c5d8f8e84832d9124861bdd1abbc9