### PR TITLE
Fix drive grep link update

### DIFF
--- a/__tests__/handlers/selectMenus/driveGrepSelect.test.js
+++ b/__tests__/handlers/selectMenus/driveGrepSelect.test.js
@@ -37,17 +37,17 @@ describe('driveGrepSelect', () => {
     gMock.getMock
       .mockResolvedValueOnce({ data: { name: 'file.txt', mimeType: 'text/plain' } })
       .mockResolvedValueOnce({ data: Buffer.from('abc') });
-    const deferReply = jest.fn();
+    const deferUpdate = jest.fn();
     const editReply = jest.fn();
     const interaction = {
       customId: 'drive_grep_select_1',
       user: { id: '1' },
       values: ['fileId'],
-      deferReply,
+      deferUpdate,
       editReply,
     };
     await handler(interaction);
-    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(deferUpdate).toHaveBeenCalled();
     expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ files: [expect.objectContaining({ name: 'file.txt' })] }));
   });
 
@@ -55,13 +55,13 @@ describe('driveGrepSelect', () => {
     driveAuthMock.getClient.mockResolvedValue({});
     gMock.getMock.mockResolvedValueOnce({ data: { name: 'Doc', mimeType: 'application/vnd.google-apps.document' } });
     gMock.exportMock.mockResolvedValueOnce({ data: Buffer.from('pdf') });
-    const deferReply = jest.fn();
+    const deferUpdate = jest.fn();
     const editReply = jest.fn();
     const interaction = {
       customId: 'drive_grep_select_1',
       user: { id: '1' },
       values: ['fileId'],
-      deferReply,
+      deferUpdate,
       editReply,
     };
     await handler(interaction);
@@ -76,18 +76,19 @@ describe('driveGrepSelect', () => {
 
   test('handles errors gracefully', async () => {
     driveAuthMock.getClient.mockRejectedValue(new Error('bad'));
-    const deferReply = jest.fn();
+    const deferUpdate = jest.fn();
     const editReply = jest.fn();
     const interaction = {
       customId: 'drive_grep_select_1',
       user: { id: '1' },
       values: ['fileId'],
-      deferReply,
+      deferUpdate,
       editReply,
     };
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    await handler(interaction);
-    expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error') }));
-    errorSpy.mockRestore();
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  await handler(interaction);
+  expect(deferUpdate).toHaveBeenCalled();
+  expect(editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Error') }));
+  errorSpy.mockRestore();
   });
 });

--- a/handlers/selectMenus/driveGrepSelect.js
+++ b/handlers/selectMenus/driveGrepSelect.js
@@ -13,7 +13,7 @@ module.exports = async function driveGrepSelect(interaction) {
   }
 
   const fileId = interaction.values[0];
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferUpdate();
 
   try {
     const auth = await driveAuth.getClient();
@@ -38,11 +38,12 @@ module.exports = async function driveGrepSelect(interaction) {
     }
 
     await interaction.editReply({
-      content: `📥 Downloading **${fileName}**`,
+      content: `📥 Download **${fileName}**`,
       files: [{ attachment: Buffer.from(fileData), name: fileName }],
+      components: [],
     });
   } catch (err) {
     console.error('[drive:grep_select] Error downloading file:', err);
-    await interaction.editReply({ content: '❌ Error downloading file.' });
+    await interaction.editReply({ content: '❌ Error downloading file.', components: [] });
   }
 };


### PR DESCRIPTION
## Summary
- update `driveGrepSelect` handler to edit the original message instead of sending a new reply
- adjust tests for the updated interaction flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c5e149ff4832db9996d84f86c627e