### PR TITLE
fix: schedule embed uses Mountain time

### DIFF
--- a/__tests__/utils/scheduleFormatter.test.js
+++ b/__tests__/utils/scheduleFormatter.test.js
@@ -51,4 +51,11 @@ describe('formatScheduleList', () => {
     const result = formatScheduleList(events);
     expect(result).toContain('(All Day)');
   });
+
+  it('formats times in Mountain Time', () => {
+    const start = new Date('2025-06-01T16:00:00Z');
+    const events = [{ summary: 'Meeting', startTime: start }];
+    const result = formatScheduleList(events);
+    expect(result).toContain('10:00 AM');
+  });
 });

--- a/utils/scheduleFormatter.js
+++ b/utils/scheduleFormatter.js
@@ -34,9 +34,10 @@ module.exports = function formatScheduleList(events) {
         return `🗓 **(All Day)** ${summary}${location ? ` @ ${location}` : ''}`;
       }
 
-      const time = ev.startTime.toLocaleTimeString(undefined, {
+      const time = ev.startTime.toLocaleTimeString('en-US', {
         hour: '2-digit',
         minute: '2-digit',
+        timeZone: 'America/Denver',
       });
 
       return `🕒 **${time}** ${summary}${location ? ` @ ${location}` : ''}`;


### PR DESCRIPTION
## Summary
- display schedule times in America/Denver timezone
- add unit test verifying Mountain Time formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c628e4d7c832d9ce38b0bf6d137f3