### PR TITLE
fix: update schedule channel when calendar updates

### DIFF
--- a/__tests__/utils/dailySchedulePoster.test.js
+++ b/__tests__/utils/dailySchedulePoster.test.js
@@ -12,12 +12,27 @@ const mockChannel = () => ({
   messages: { fetch: jest.fn().mockResolvedValue({ edit: jest.fn() }) }
 });
 
+const parseDateInDenver = (dateStr) => {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const utc = new Date(Date.UTC(y, m - 1, d, 0, 0, 0));
+  const local = new Date(utc.toLocaleString('en-US', { timeZone: 'America/Denver' }));
+  const offset = utc.getTime() - local.getTime();
+  return new Date(utc.getTime() + offset);
+};
+
 describe('dailySchedulePoster', () => {
   beforeEach(() => jest.clearAllMocks());
 
   test('isTodayMountain detects same day', () => {
     const now = new Date();
     expect(isTodayMountain(now)).toBe(true);
+  });
+
+  test('isTodayMountain handles all-day events', () => {
+    const mtDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Denver' }));
+    const dateStr = mtDate.toISOString().slice(0, 10);
+    const allDayUtc = parseDateInDenver(dateStr);
+    expect(isTodayMountain(allDayUtc)).toBe(true);
   });
 
   test('posts new message when none exists', async () => {

--- a/utils/dailySchedulePoster.js
+++ b/utils/dailySchedulePoster.js
@@ -9,12 +9,13 @@ function getTimezoneOffset(zone, date = new Date()) {
 }
 
 function isTodayMountain(date) {
-  const offset = getTimezoneOffset('America/Denver');
-  const nowMt = new Date(Date.now() - offset);
-  const dateMt = new Date(date.getTime() - offset);
-  return nowMt.getFullYear() === dateMt.getFullYear() &&
-    nowMt.getMonth() === dateMt.getMonth() &&
-    nowMt.getDate() === dateMt.getDate();
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Denver',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+  return fmt.format(date) === fmt.format(new Date());
 }
 
 async function postScheduleForToday(client, guildId) {


### PR DESCRIPTION
## Summary
- correctly parse all-day events in Mountain timezone
- improve date check for daily schedule
- add regression test for all-day events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c649e64b4832d8811fcfa19b6cbdc