### PR TITLE
Improve calendar command coverage

### DIFF
--- a/__tests__/commands/calendar/edit.test.js
+++ b/__tests__/commands/calendar/edit.test.js
@@ -4,7 +4,18 @@ jest.mock('../../../db/models/CalendarConfig', () => {
 });
 
 jest.mock('discord.js', () => {
-  class Fake { setCustomId(){return this;} setTitle(){return this;} addComponents(){return this;} setLabel(){return this;} setStyle(){return this;} setRequired(){return this;} setPlaceholder(){return this;} addOptions(){return this;} }
+  class Fake {
+    setCustomId(){return this;}
+    setTitle(){return this;}
+    addComponents(){return this;}
+    setLabel(){return this;}
+    setStyle(){return this;}
+    setRequired(){return this;}
+    setPlaceholder(){return this;}
+    addOptions(){return this;}
+    setValue(){return this;}
+    setDescription(){return this;}
+  }
   return { ModalBuilder: Fake, TextInputBuilder: Fake, TextInputStyle: { Short: 1 }, ActionRowBuilder: Fake, StringSelectMenuBuilder: Fake, StringSelectMenuOptionBuilder: Fake };
 });
 
@@ -27,5 +38,17 @@ describe('calendar edit', () => {
     const showModal = jest.fn();
     await edit({ showModal }, 'g1');
     expect(showModal).toHaveBeenCalled();
+  });
+
+  test('presents select when multiple calendars', async () => {
+    findAll.mockResolvedValue([
+      { id: 1, label: 'a', calendarId: 'c1' },
+      { id: 2, label: 'b', calendarId: 'c2' }
+    ]);
+    const reply = jest.fn();
+    await edit({ reply }, 'g1');
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true, components: expect.any(Array) })
+    );
   });
 });

--- a/__tests__/commands/calendar/list_channels.test.js
+++ b/__tests__/commands/calendar/list_channels.test.js
@@ -24,4 +24,19 @@ describe('calendar list-channels', () => {
     await list({ guild, reply }, 'g');
     expect(reply).toHaveBeenCalled();
   });
+
+  test('unknown channel handled', async () => {
+    findAll.mockResolvedValue([{ channelId: '1' }]);
+    const reply = jest.fn();
+    const guild = { channels: { cache: new Map() } };
+    await list({ guild, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('errors are caught', async () => {
+    findAll.mockRejectedValue(new Error('fail'));
+    const reply = jest.fn();
+    await list({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
 });

--- a/__tests__/commands/calendar/remove.test.js
+++ b/__tests__/commands/calendar/remove.test.js
@@ -1,4 +1,9 @@
 jest.mock('../../../db/models/CalendarConfig', () => { const findAll = jest.fn(); return { findAll, __esModule: true, __mock: { findAll } }; });
+
+jest.mock('discord.js', () => {
+  class Fake { setCustomId(){return this;} setPlaceholder(){return this;} addOptions(){return this;} setLabel(){return this;} setValue(){return this;} setDescription(){return this;} addComponents(){return this;} }
+  return { ActionRowBuilder: Fake, StringSelectMenuBuilder: Fake, StringSelectMenuOptionBuilder: Fake };
+});
 const { __mock } = require('../../../db/models/CalendarConfig');
 const findAll = __mock.findAll;
 const remove = require('../../../commands/calendar/remove');
@@ -20,5 +25,17 @@ describe('calendar remove', () => {
     await remove({ reply }, 'g');
     expect(destroy).toHaveBeenCalled();
     expect(reply).toHaveBeenCalled();
+  });
+
+  test('shows menu when multiple calendars', async () => {
+    findAll.mockResolvedValue([
+      { id: 1, label: 'a', calendarId: 'c1' },
+      { id: 2, label: 'b', calendarId: 'c2' }
+    ]);
+    const reply = jest.fn();
+    await remove({ reply }, 'g');
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true, components: expect.any(Array) })
+    );
   });
 });

--- a/__tests__/commands/calendar/remove_channel.test.js
+++ b/__tests__/commands/calendar/remove_channel.test.js
@@ -22,4 +22,12 @@ describe('calendar remove-channel', () => {
     await handler({ options, reply }, 'g');
     expect(reply).toHaveBeenCalled();
   });
+
+  test('handles errors', async () => {
+    destroy.mockRejectedValue(new Error('fail'));
+    const reply = jest.fn();
+    const options = { getString: jest.fn(() => '1') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
 });

--- a/__tests__/commands/calendar/set_daterange.test.js
+++ b/__tests__/commands/calendar/set_daterange.test.js
@@ -25,4 +25,31 @@ describe('calendar set-daterange', () => {
     expect(update).toHaveBeenCalled();
     expect(reply).toHaveBeenCalled();
   });
+
+  test('invalid date values', async () => {
+    const reply = jest.fn();
+    const options = { getString: jest.fn(key => key === 'start' ? '2023-99-99' : '2023-01-01') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('start after end', async () => {
+    const reply = jest.fn();
+    const options = { getString: jest.fn(key => key === 'start' ? '2023-01-02' : '2023-01-01') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('multiple calendars shows select', async () => {
+    findAll.mockResolvedValue([
+      { calendarId: 'a', label: 'A' },
+      { calendarId: 'b', label: 'B' }
+    ]);
+    const reply = jest.fn();
+    const options = { getString: jest.fn(key => key === 'start' ? '2023-01-01' : '2023-01-02') };
+    await handler({ options, reply }, 'g');
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true, components: expect.any(Array) })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- expand tests for calendar edit, remove, set-daterange
- add failure cases for list-channels and remove-channel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c69d7ffe0832dbd5e2fb392ed9417