### PR TITLE
Add comprehensive tests for schedule today

### DIFF
--- a/__tests__/commands/schedule/today.test.js
+++ b/__tests__/commands/schedule/today.test.js
@@ -5,6 +5,7 @@ jest.mock('../../../utils/scheduleEmbedBuilder', () => jest.fn(() => ({ data: {}
 const { __mock } = require('../../../db/models');
 const configFind = __mock.findOne;
 const eventFind = __mock.findAll;
+const scheduleEmbedBuilder = require('../../../utils/scheduleEmbedBuilder');
 const todayCmd = require('../../../commands/schedule/today');
 
 describe('schedule today', () => {
@@ -15,6 +16,40 @@ describe('schedule today', () => {
     eventFind.mockResolvedValue([]);
     const reply = jest.fn();
     await todayCmd({ reply }, 'g');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('calendar not configured', async () => {
+    configFind.mockResolvedValue(null);
+    const reply = jest.fn();
+    await todayCmd({ reply }, 'g');
+    expect(scheduleEmbedBuilder).toHaveBeenCalledWith(
+      '⚠️ Calendar Range Not Configured',
+      'Configure a calendar date range first.',
+      0xFFAA00
+    );
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('shows events list', async () => {
+    configFind.mockResolvedValue({ startDate: '2023-01-01', endDate: '2023-12-31' });
+    eventFind.mockResolvedValue([{ startTime: new Date(), summary: 'event' }]);
+    const reply = jest.fn();
+    await todayCmd({ reply }, 'g');
+    expect(eventFind).toHaveBeenCalled();
+    expect(scheduleEmbedBuilder).toHaveBeenCalledWith("Today's Schedule", 'list');
+    expect(reply).toHaveBeenCalled();
+  });
+
+  test('handles errors gracefully', async () => {
+    configFind.mockRejectedValue(new Error('fail'));
+    const reply = jest.fn();
+    await todayCmd({ reply }, 'g');
+    expect(scheduleEmbedBuilder).toHaveBeenCalledWith(
+      'Today’s Schedule',
+      'No events scheduled for today.',
+      0xCCCCCC
+    );
     expect(reply).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- improve test coverage for `commands/schedule/today.js`

## Testing
- `npm test -- -i`


------
https://chatgpt.com/codex/tasks/task_b_683c69cc4b14832db8a61cb71db23a53